### PR TITLE
fix(version): incorrect "v" char displayed

### DIFF
--- a/frontend/src/locale/en.yml
+++ b/frontend/src/locale/en.yml
@@ -47,7 +47,7 @@ common:
     next: 'Next'
 auth:
     welcome: 'Welcome to {appName},'
-    runningOn: 'Running on FeatherPanel v{version} - {appName}'
+    runningOn: 'Running on FeatherPanel {version} - {appName}'
     mythicalSystems: 'mythical.systems'
     login: 'Login'
     register: 'Register'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the FeatherPanel version display format in the authentication message to remove the "v" prefix from the version number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->