### PR TITLE
Potential fix for code scanning alert no. 25: Replacement of a substring with itself

### DIFF
--- a/featherpanel-frontendv2/src/components/servers/StatusBadge.tsx
+++ b/featherpanel-frontendv2/src/components/servers/StatusBadge.tsx
@@ -49,7 +49,7 @@ export function StatusBadge({ status, t }: StatusBadgeProps) {
                 colors[status as keyof typeof colors] || colors.stopped,
             )}
         >
-            <span className={cn('h-2 w-2 rounded-full', getStatusDotColor(status).replace('bg-', 'bg-'))} />
+            <span className={cn('h-2 w-2 rounded-full', getStatusDotColor(status))} />
             {displayStatus}
         </span>
     );


### PR DESCRIPTION
Potential fix for [https://github.com/MythicalLTD/FeatherPanel/security/code-scanning/25](https://github.com/MythicalLTD/FeatherPanel/security/code-scanning/25)

To fix this, remove the no-op `.replace('bg-', 'bg-')` call so that the className is just `getStatusDotColor(status)` combined with the base classes. This preserves existing behavior (because the replacement did nothing) while eliminating the confusing and unnecessary string replacement and satisfying the static analysis rule.

Concretely, in `featherpanel-frontendv2/src/components/servers/StatusBadge.tsx`, on line 52, update the inner `<span>` so that its `className` uses `cn('h-2 w-2 rounded-full', getStatusDotColor(status))` instead of applying `.replace('bg-', 'bg-')`. No imports or other definitions need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Cleans up a redundant string operation flagged by code scanning with no functional impact.
> 
> - In `featherpanel-frontendv2/src/components/servers/StatusBadge.tsx`, replace `cn('h-2 w-2 rounded-full', getStatusDotColor(status).replace('bg-', 'bg-'))` with `cn('h-2 w-2 rounded-full', getStatusDotColor(status))`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0a878fb067fe69c5291869c6376979f5cd9f83bd. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed status indicator styling to display correctly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->