### PR TITLE
Change account deletion email subject line

### DIFF
--- a/backend/app/Controllers/Admin/UsersController.php
+++ b/backend/app/Controllers/Admin/UsersController.php
@@ -948,7 +948,7 @@ class UsersController
         try {
             AccountDeleted::send([
                 'email' => $user['email'],
-                'subject' => 'Welcome to ' . $config->getSetting(ConfigInterface::APP_NAME, 'FeatherPanel'),
+                'subject' => 'Your ' . $config->getSetting(ConfigInterface::APP_NAME, 'FeatherPanel') . ' account has been deleted',
                 'app_name' => $config->getSetting(ConfigInterface::APP_NAME, 'FeatherPanel'),
                 'app_url' => $config->getSetting(ConfigInterface::APP_URL, 'https://featherpanel.mythical.systems'),
                 'first_name' => $user['first_name'],


### PR DESCRIPTION
Fix for Default Template Subject for deleted users

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the email subject line sent to users when their account is deleted. The notification now displays a deletion-specific message instead of an incorrect welcome message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->