### PR TITLE
Add error toast for empty spells in addSpell function

### DIFF
--- a/frontendv2/src/app/(app)/admin/subdomains/page.tsx
+++ b/frontendv2/src/app/(app)/admin/subdomains/page.tsx
@@ -431,7 +431,10 @@ export default function AdminSubdomainsPage() {
     };
 
     const addSpell = () => {
-        if (spells.length === 0) return;
+        if (spells.length === 0) {
+            toast.error('Please create a spell first in the Spells section.');
+            return;
+        }
         setDomainForm((prev) => ({
             ...prev,
             spells: [


### PR DESCRIPTION
Shows error notification when attempting to add a spell mapping without any spells configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added error message feedback when attempting to add a spell without first creating one. Users now receive a clear notification explaining that a spell must be created before proceeding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->