### PR TITLE
Use external status page URL in navigation from settings

### DIFF
--- a/frontendv2/src/config/navigation.tsx
+++ b/frontendv2/src/config/navigation.tsx
@@ -928,7 +928,7 @@ export const getMainNavigationItems = (
             id: 'status',
             name: t('navigation.items.status'),
             title: t('navigation.items.status'),
-            url: '/dashboard/status',
+            url: settings?.status_page_url || '/dashboard/status',
             icon: Activity,
             isActive: false,
             category: 'main',


### PR DESCRIPTION
Updates the sidebar navigation to use the status_page_url from system settings, allowing the Status link to redirect to an external page while falling back to the default dashboard route if no URL is provided.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Status page link can now be customized through configuration settings, with automatic fallback to the default status page when not configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->