### PR TITLE
Fix PageCard description text overflow

### DIFF
--- a/frontendv2/src/components/featherui/PageCard.tsx
+++ b/frontendv2/src/components/featherui/PageCard.tsx
@@ -116,7 +116,7 @@ export function PageCard({
                             {title}
                         </h2>
                         {description && (
-                            <p className='text-muted-foreground truncate text-[9px] font-bold tracking-widest uppercase opacity-50'>
+                            <p className='text-muted-foreground line-clamp-2 text-[9px] font-bold tracking-widest uppercase opacity-50'>
                                 {description}
                             </p>
                         )}


### PR DESCRIPTION
Changed the CSS utility class from `truncate` to `line-clamp-2` for the card description. This ensures long text wraps onto a maximum of two lines with an ellipsis instead of clipping horizontally and breaking the card layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated description text rendering in page cards to use line-clamping instead of truncation for improved text display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/MythicalLTD/FeatherPanel/pull/176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->