### PR TITLE
fix: behind_proxy setting ignored across ~30 files, not just WingsAdminController

### DIFF
--- a/backend/app/Controllers/Admin/FeatherZeroTrustController.php
+++ b/backend/app/Controllers/Admin/FeatherZeroTrustController.php
@@ -17,6 +17,7 @@
 
 namespace App\Controllers\Admin;
 
+use App\Helpers\WingsUrlHelper;
 use App\App;
 use App\Chat\Node;
 use App\Chat\Server;
@@ -167,7 +168,8 @@ class FeatherZeroTrustController
                 $node['daemonListen'],
                 $node['scheme'],
                 $node['daemon_token'],
-                30
+                30,
+                WingsUrlHelper::isBehindProxy($node)
             );
 
             // Create configuration
@@ -309,7 +311,8 @@ class FeatherZeroTrustController
                         $node['daemonListen'],
                         $node['scheme'],
                         $node['daemon_token'],
-                        30
+                        30,
+                        WingsUrlHelper::isBehindProxy($node)
                     );
 
                     // Create scanner

--- a/backend/app/Controllers/Admin/NodeStatusController.php
+++ b/backend/app/Controllers/Admin/NodeStatusController.php
@@ -17,6 +17,7 @@
 
 namespace App\Controllers\Admin;
 
+use App\Helpers\WingsUrlHelper;
 use App\Chat\Node;
 use App\Helpers\ApiResponse;
 use App\Services\Wings\Wings;
@@ -100,7 +101,8 @@ class NodeStatusController
                     $node['daemonListen'],
                     $node['scheme'],
                     $node['daemon_token'],
-                    10 // Short timeout for status checks
+                    10 // Short timeout for status checks,
+                    WingsUrlHelper::isBehindProxy($node)
                 );
 
                 $utilization = $wings->getSystem()->getSystemUtilization();

--- a/backend/app/Controllers/Admin/NodeStatusController.php
+++ b/backend/app/Controllers/Admin/NodeStatusController.php
@@ -101,7 +101,7 @@ class NodeStatusController
                     $node['daemonListen'],
                     $node['scheme'],
                     $node['daemon_token'],
-                    10 // Short timeout for status checks,
+                    10, // Short timeout for status checks
                     WingsUrlHelper::isBehindProxy($node)
                 );
 

--- a/backend/app/Controllers/Admin/NodesController.php
+++ b/backend/app/Controllers/Admin/NodesController.php
@@ -1143,7 +1143,7 @@ class NodesController
                 (int) $node['daemonListen'],
                 $node['scheme'],
                 $node['daemon_token'],
-                ($timeoutSeconds ?? 60) + 10 // Add 10s buffer for HTTP timeout,
+                ($timeoutSeconds ?? 60) + 10, // Add 10s buffer for HTTP timeout
                 WingsUrlHelper::isBehindProxy($node)
             );
 
@@ -1569,7 +1569,7 @@ class NodesController
                 (int) $node['daemonListen'],
                 $node['scheme'],
                 $node['daemon_token'],
-                10 // Short timeout for version check,
+                10, // Short timeout for version check
                 WingsUrlHelper::isBehindProxy($node)
             );
 

--- a/backend/app/Controllers/Admin/NodesController.php
+++ b/backend/app/Controllers/Admin/NodesController.php
@@ -17,6 +17,7 @@
 
 namespace App\Controllers\Admin;
 
+use App\Helpers\WingsUrlHelper;
 use App\App;
 use App\Chat\Node;
 use App\Cache\Cache;
@@ -754,7 +755,8 @@ class NodesController
                 (int) $node['daemonListen'],
                 $node['scheme'],
                 $node['daemon_token'],
-                30
+                30,
+                WingsUrlHelper::isBehindProxy($node)
             );
 
             $diagnostics = $wings->getSystem()->getDiagnostics(
@@ -899,7 +901,8 @@ class NodesController
                 (int) $node['daemonListen'],
                 $node['scheme'],
                 $node['daemon_token'],
-                30
+                30,
+                WingsUrlHelper::isBehindProxy($node)
             );
 
             $response = $wings->getSystem()->triggerSelfUpdate($cleanPayload, true);
@@ -1140,7 +1143,8 @@ class NodesController
                 (int) $node['daemonListen'],
                 $node['scheme'],
                 $node['daemon_token'],
-                ($timeoutSeconds ?? 60) + 10 // Add 10s buffer for HTTP timeout
+                ($timeoutSeconds ?? 60) + 10 // Add 10s buffer for HTTP timeout,
+                WingsUrlHelper::isBehindProxy($node)
             );
 
             $result = $wings->getSystem()->executeCommand(
@@ -1231,7 +1235,8 @@ class NodesController
                 (int) $node['daemonListen'],
                 $node['scheme'],
                 $node['daemon_token'],
-                30
+                30,
+                WingsUrlHelper::isBehindProxy($node)
             );
 
             $config = $wings->getConfig()->getConfig();
@@ -1313,7 +1318,8 @@ class NodesController
                 (int) $node['daemonListen'],
                 $node['scheme'],
                 $node['daemon_token'],
-                30
+                30,
+                WingsUrlHelper::isBehindProxy($node)
             );
 
             // Wings API expects 'content' field, not 'config'
@@ -1433,7 +1439,8 @@ class NodesController
                 (int) $node['daemonListen'],
                 $node['scheme'],
                 $node['daemon_token'],
-                30
+                30,
+                WingsUrlHelper::isBehindProxy($node)
             );
 
             // Wings API expects 'updates' field in patchConfig, but we accept 'values' from frontend
@@ -1499,7 +1506,8 @@ class NodesController
                 (int) $node['daemonListen'],
                 $node['scheme'],
                 $node['daemon_token'],
-                30
+                30,
+                WingsUrlHelper::isBehindProxy($node)
             );
 
             $schema = $wings->getConfig()->getConfigSchema();
@@ -1561,7 +1569,8 @@ class NodesController
                 (int) $node['daemonListen'],
                 $node['scheme'],
                 $node['daemon_token'],
-                10 // Short timeout for version check
+                10 // Short timeout for version check,
+                WingsUrlHelper::isBehindProxy($node)
             );
 
             // Get current Wings version

--- a/backend/app/Controllers/Admin/ServersController.php
+++ b/backend/app/Controllers/Admin/ServersController.php
@@ -17,6 +17,7 @@
 
 namespace App\Controllers\Admin;
 
+use App\Helpers\WingsUrlHelper;
 use App\App;
 use App\Chat\Node;
 use App\Chat\User;
@@ -1180,7 +1181,8 @@ class ServersController
                 $port,
                 $scheme,
                 $token,
-                $timeout
+                $timeout,
+                WingsUrlHelper::isBehindProxy($nodeInfo)
             );
 
             $wingsData = [
@@ -1764,7 +1766,8 @@ class ServersController
                             $nodeInfo['daemonListen'],
                             $nodeInfo['scheme'],
                             $nodeInfo['daemon_token'],
-                            30
+                            30,
+                            WingsUrlHelper::isBehindProxy($nodeInfo)
                         );
 
                         // Deauthorize old owner from Wings
@@ -1904,7 +1907,8 @@ class ServersController
                         $port,
                         $scheme,
                         $token,
-                        $timeout
+                        $timeout,
+                        WingsUrlHelper::isBehindProxy($nodeInfo)
                     );
 
                     // If spell changed, trigger reinstall instead of just sync
@@ -2057,7 +2061,8 @@ class ServersController
                 $port,
                 $scheme,
                 $token,
-                $timeout
+                $timeout,
+                WingsUrlHelper::isBehindProxy($nodeInfo)
             );
 
             $response = $wings->getServer()->deleteServer($server['uuid']);
@@ -2572,7 +2577,8 @@ class ServersController
                 $port,
                 $scheme,
                 $token,
-                $timeout
+                $timeout,
+                WingsUrlHelper::isBehindProxy($nodeInfo)
             );
 
             $response = $wings->getServer()->killServer($server['uuid']);
@@ -2916,7 +2922,8 @@ class ServersController
                         $sourceNode['daemonListen'],
                         $sourceNode['scheme'],
                         $sourceNode['daemon_token'],
-                        30
+                        30,
+                        WingsUrlHelper::isBehindProxy($sourceNode)
                     );
                     $wingsSource->getTransfer()->cancelTransfer($server['uuid']);
                     $logger->info('Cancelled transfer on source node for server ' . $server['uuid']);
@@ -2933,7 +2940,8 @@ class ServersController
                         $destinationNode['daemonListen'],
                         $destinationNode['scheme'],
                         $destinationNode['daemon_token'],
-                        30
+                        30,
+                        WingsUrlHelper::isBehindProxy($destinationNode)
                     );
                     // Destination node uses DELETE /api/transfer with server UUID in body
                     $wingsDest->getServer()->deleteServer($server['uuid']);
@@ -3018,7 +3026,8 @@ class ServersController
                 $node['daemonListen'],
                 $node['scheme'],
                 $node['daemon_token'],
-                30
+                30,
+                WingsUrlHelper::isBehindProxy($node)
             );
             $response = $wings->getServer()->syncServer($server['uuid']);
             if (!$response->isSuccessful()) {

--- a/backend/app/Controllers/User/NodeStatusController.php
+++ b/backend/app/Controllers/User/NodeStatusController.php
@@ -150,7 +150,7 @@ class NodeStatusController
                         $node['daemonListen'],
                         $node['scheme'],
                         $node['daemon_token'],
-                        10 // Short timeout for status checks,
+                        10, // Short timeout for status checks
                         WingsUrlHelper::isBehindProxy($node)
                     );
 

--- a/backend/app/Controllers/User/NodeStatusController.php
+++ b/backend/app/Controllers/User/NodeStatusController.php
@@ -17,6 +17,7 @@
 
 namespace App\Controllers\User;
 
+use App\Helpers\WingsUrlHelper;
 use App\App;
 use App\Chat\Node;
 use App\Chat\Server;
@@ -149,7 +150,8 @@ class NodeStatusController
                         $node['daemonListen'],
                         $node['scheme'],
                         $node['daemon_token'],
-                        10 // Short timeout for status checks
+                        10 // Short timeout for status checks,
+                        WingsUrlHelper::isBehindProxy($node)
                     );
 
                     $utilization = $wings->getSystem()->getSystemUtilization();

--- a/backend/app/Controllers/User/Server/Logs/ServerLogsController.php
+++ b/backend/app/Controllers/User/Server/Logs/ServerLogsController.php
@@ -17,6 +17,7 @@
 
 namespace App\Controllers\User\Server\Logs;
 
+use App\Helpers\WingsUrlHelper;
 use App\App;
 use App\Chat\Server;
 use App\Helpers\LogHelper;
@@ -117,7 +118,8 @@ class ServerLogsController
                 $port,
                 $scheme,
                 $token,
-                $timeout
+                $timeout,
+                WingsUrlHelper::isBehindProxy($node)
             );
 
             $response = $wings->getServer()->getServerLogs($server['uuid']);
@@ -215,7 +217,8 @@ class ServerLogsController
                 $port,
                 $scheme,
                 $token,
-                $timeout
+                $timeout,
+                WingsUrlHelper::isBehindProxy($node)
             );
 
             $response = $wings->getServer()->getServerInstallLogs($server['uuid']);
@@ -318,7 +321,8 @@ class ServerLogsController
                 $port,
                 $scheme,
                 $token,
-                $timeout
+                $timeout,
+                WingsUrlHelper::isBehindProxy($node)
             );
 
             $response = $wings->getServer()->getServerLogs($server['uuid']);
@@ -450,7 +454,8 @@ class ServerLogsController
                 $port,
                 $scheme,
                 $token,
-                $timeout
+                $timeout,
+                WingsUrlHelper::isBehindProxy($node)
             );
 
             $response = $wings->getServer()->getServerInstallLogs($server['uuid']);

--- a/backend/app/Controllers/User/Server/Power/ServerPowerController.php
+++ b/backend/app/Controllers/User/Server/Power/ServerPowerController.php
@@ -17,6 +17,7 @@
 
 namespace App\Controllers\User\Server\Power;
 
+use App\Helpers\WingsUrlHelper;
 use App\App;
 use App\Chat\Server;
 use App\SubuserPermissions;
@@ -153,7 +154,8 @@ class ServerPowerController
                 $port,
                 $scheme,
                 $token,
-                $timeout
+                $timeout,
+                WingsUrlHelper::isBehindProxy($node)
             );
 
             if ($action === 'start') {

--- a/backend/app/Controllers/User/Server/ServerBackupController.php
+++ b/backend/app/Controllers/User/Server/ServerBackupController.php
@@ -345,7 +345,8 @@ class ServerBackupController
                     (int) $nodeForEvict['daemonListen'],
                     $nodeForEvict['scheme'],
                     $nodeForEvict['daemon_token'],
-                    30
+                    30,
+                    WingsUrlHelper::isBehindProxy($nodeForEvict)
                 );
             } catch (\Throwable $e) {
                 App::getInstance(true)->getLogger()->error('FIFO backup eviction: Wings client error: ' . $e->getMessage());
@@ -404,7 +405,8 @@ class ServerBackupController
                 $port,
                 $scheme,
                 $token,
-                $timeout
+                $timeout,
+                WingsUrlHelper::isBehindProxy($node)
             );
 
             // Initiate backup on Wings
@@ -575,7 +577,8 @@ class ServerBackupController
                 $port,
                 $scheme,
                 $token,
-                $timeout
+                $timeout,
+                WingsUrlHelper::isBehindProxy($node)
             );
 
             // Initiate restore on Wings
@@ -926,7 +929,8 @@ class ServerBackupController
                 $port,
                 $scheme,
                 $token,
-                $timeout
+                $timeout,
+                WingsUrlHelper::isBehindProxy($node)
             );
 
             // Delete backup on Wings

--- a/backend/app/Controllers/Wings/Transfer/WingsTransferStatusController.php
+++ b/backend/app/Controllers/Wings/Transfer/WingsTransferStatusController.php
@@ -17,6 +17,7 @@
 
 namespace App\Controllers\Wings\Transfer;
 
+use App\Helpers\WingsUrlHelper;
 use App\App;
 use App\Chat\Node;
 use App\Chat\Backup;
@@ -411,7 +412,8 @@ class WingsTransferStatusController
                 $oldNode['daemonListen'],
                 $oldNode['scheme'],
                 $oldNode['daemon_token'],
-                30
+                30,
+                WingsUrlHelper::isBehindProxy($oldNode)
             );
 
             // Delete the server from the old node

--- a/backend/app/Controllers/Wings/WingsAdminController.php
+++ b/backend/app/Controllers/Wings/WingsAdminController.php
@@ -20,6 +20,7 @@ namespace App\Controllers\Wings;
 use App\Chat\Node;
 use App\Helpers\ApiResponse;
 use App\Services\Wings\Wings;
+use App\Helpers\WingsUrlHelper;
 use OpenApi\Attributes as OA;
 use App\Plugins\Events\Events\WingsEvent;
 use Symfony\Component\HttpFoundation\Request;
@@ -142,7 +143,8 @@ class WingsAdminController
             $port,
             $scheme,
             $token,
-            $timeout
+            $timeout,
+            WingsUrlHelper::isBehindProxy($node)
         );
 
         $utilization = $wings->getSystem()->getSystemUtilization();
@@ -208,7 +210,8 @@ class WingsAdminController
             $port,
             $scheme,
             $token,
-            $timeout
+            $timeout,
+            WingsUrlHelper::isBehindProxy($node)
         );
 
         $dockerDiskUsage = $wings->getDocker()->getDockerDiskUsage();
@@ -274,7 +277,8 @@ class WingsAdminController
             $port,
             $scheme,
             $token,
-            $timeout
+            $timeout,
+            WingsUrlHelper::isBehindProxy($node)
         );
 
         $dockerPrune = $wings->getDocker()->pruneDockerImages();
@@ -340,7 +344,8 @@ class WingsAdminController
             $port,
             $scheme,
             $token,
-            $timeout
+            $timeout,
+            WingsUrlHelper::isBehindProxy($node)
         );
 
         $ips = $wings->getSystem()->getSystemIPs();
@@ -425,7 +430,8 @@ class WingsAdminController
             $port,
             $scheme,
             $token,
-            $timeout
+            $timeout,
+            WingsUrlHelper::isBehindProxy($node)
         );
 
         $system = $wings->getSystem()->getDetailedSystemInfo();
@@ -488,7 +494,8 @@ class WingsAdminController
             $port,
             $scheme,
             $token,
-            $timeout
+            $timeout,
+            WingsUrlHelper::isBehindProxy($node)
         );
 
         $modules = $wings->getModule()->listModules();
@@ -545,7 +552,8 @@ class WingsAdminController
             $port,
             $scheme,
             $token,
-            $timeout
+            $timeout,
+            WingsUrlHelper::isBehindProxy($node)
         );
 
         $config = $wings->getModule()->getModuleConfig($module);
@@ -607,7 +615,8 @@ class WingsAdminController
             $port,
             $scheme,
             $token,
-            $timeout
+            $timeout,
+            WingsUrlHelper::isBehindProxy($node)
         );
 
         $config = $wings->getModule()->updateModuleConfig($module, $requestData['config']);
@@ -664,7 +673,8 @@ class WingsAdminController
             $port,
             $scheme,
             $token,
-            $timeout
+            $timeout,
+            WingsUrlHelper::isBehindProxy($node)
         );
 
         $result = $wings->getModule()->enableModule($module);
@@ -721,7 +731,8 @@ class WingsAdminController
             $port,
             $scheme,
             $token,
-            $timeout
+            $timeout,
+            WingsUrlHelper::isBehindProxy($node)
         );
 
         $result = $wings->getModule()->disableModule($module);

--- a/backend/app/Services/Chatbot/Tools/AutoAllocateTool.php
+++ b/backend/app/Services/Chatbot/Tools/AutoAllocateTool.php
@@ -17,6 +17,7 @@
 
 namespace App\Services\Chatbot\Tools;
 
+use App\Helpers\WingsUrlHelper;
 use App\App;
 use App\Chat\Node;
 use App\Chat\Server;
@@ -148,7 +149,8 @@ class AutoAllocateTool implements ToolInterface
                     $node['daemonListen'],
                     $node['scheme'],
                     $node['daemon_token'],
-                    30
+                    30,
+                    WingsUrlHelper::isBehindProxy($node)
                 );
 
                 $response = $wings->getServer()->syncServer($server['uuid']);

--- a/backend/app/Services/Chatbot/Tools/CompressFilesTool.php
+++ b/backend/app/Services/Chatbot/Tools/CompressFilesTool.php
@@ -17,6 +17,7 @@
 
 namespace App\Services\Chatbot\Tools;
 
+use App\Helpers\WingsUrlHelper;
 use App\App;
 use App\Chat\Node;
 use App\Chat\Server;
@@ -141,7 +142,9 @@ class CompressFilesTool implements ToolInterface
                 $node['fqdn'],
                 $node['daemonListen'],
                 $node['scheme'],
-                $node['daemon_token']
+                $node['daemon_token'],
+                WingsUrlHelper::isBehindProxy($node),
+                WingsUrlHelper::isBehindProxy($node)
             );
 
             $response = $wings->getServer()->compressFiles($server['uuid'], $root, $files, $name, $extension);

--- a/backend/app/Services/Chatbot/Tools/CompressFilesTool.php
+++ b/backend/app/Services/Chatbot/Tools/CompressFilesTool.php
@@ -143,7 +143,7 @@ class CompressFilesTool implements ToolInterface
                 $node['daemonListen'],
                 $node['scheme'],
                 $node['daemon_token'],
-                WingsUrlHelper::isBehindProxy($node),
+                30,
                 WingsUrlHelper::isBehindProxy($node)
             );
 

--- a/backend/app/Services/Chatbot/Tools/CopyFilesTool.php
+++ b/backend/app/Services/Chatbot/Tools/CopyFilesTool.php
@@ -17,6 +17,7 @@
 
 namespace App\Services\Chatbot\Tools;
 
+use App\Helpers\WingsUrlHelper;
 use App\App;
 use App\Chat\Node;
 use App\Chat\Server;
@@ -136,7 +137,8 @@ class CopyFilesTool implements ToolInterface
                 $node['daemonListen'],
                 $node['scheme'],
                 $node['daemon_token'],
-                30
+                30,
+                WingsUrlHelper::isBehindProxy($node)
             );
 
             $response = $wings->getServer()->copyFiles($server['uuid'], $location, $files);

--- a/backend/app/Services/Chatbot/Tools/CreateBackupTool.php
+++ b/backend/app/Services/Chatbot/Tools/CreateBackupTool.php
@@ -17,6 +17,7 @@
 
 namespace App\Services\Chatbot\Tools;
 
+use App\Helpers\WingsUrlHelper;
 use App\App;
 use App\Chat\Node;
 use App\Chat\Backup;
@@ -122,7 +123,8 @@ class CreateBackupTool implements ToolInterface
                     (int) $node['daemonListen'],
                     $node['scheme'],
                     $node['daemon_token'],
-                    30
+                    30,
+                    WingsUrlHelper::isBehindProxy($node)
                 );
             } catch (\Exception $e) {
                 $this->app->getLogger()->error('CreateBackupTool FIFO: ' . $e->getMessage());
@@ -183,7 +185,8 @@ class CreateBackupTool implements ToolInterface
                 $node['daemonListen'],
                 $node['scheme'],
                 $node['daemon_token'],
-                30
+                30,
+                WingsUrlHelper::isBehindProxy($node)
             );
 
             $response = $wings->getServer()->createBackup($server['uuid'], 'wings', $backupUuid, $ignoredFiles);

--- a/backend/app/Services/Chatbot/Tools/CreateDirectoryTool.php
+++ b/backend/app/Services/Chatbot/Tools/CreateDirectoryTool.php
@@ -17,6 +17,7 @@
 
 namespace App\Services\Chatbot\Tools;
 
+use App\Helpers\WingsUrlHelper;
 use App\App;
 use App\Chat\Node;
 use App\Chat\Server;
@@ -120,7 +121,8 @@ class CreateDirectoryTool implements ToolInterface
                 $node['daemonListen'],
                 $node['scheme'],
                 $node['daemon_token'],
-                30
+                30,
+                WingsUrlHelper::isBehindProxy($node)
             );
 
             $response = $wings->getServer()->createDirectory($server['uuid'], trim($name), $path);

--- a/backend/app/Services/Chatbot/Tools/DecompressArchiveTool.php
+++ b/backend/app/Services/Chatbot/Tools/DecompressArchiveTool.php
@@ -123,7 +123,7 @@ class DecompressArchiveTool implements ToolInterface
                 $node['daemonListen'],
                 $node['scheme'],
                 $node['daemon_token'],
-                WingsUrlHelper::isBehindProxy($node),
+                30,
                 WingsUrlHelper::isBehindProxy($node)
             );
 

--- a/backend/app/Services/Chatbot/Tools/DecompressArchiveTool.php
+++ b/backend/app/Services/Chatbot/Tools/DecompressArchiveTool.php
@@ -17,6 +17,7 @@
 
 namespace App\Services\Chatbot\Tools;
 
+use App\Helpers\WingsUrlHelper;
 use App\App;
 use App\Chat\Node;
 use App\Chat\Server;
@@ -121,7 +122,9 @@ class DecompressArchiveTool implements ToolInterface
                 $node['fqdn'],
                 $node['daemonListen'],
                 $node['scheme'],
-                $node['daemon_token']
+                $node['daemon_token'],
+                WingsUrlHelper::isBehindProxy($node),
+                WingsUrlHelper::isBehindProxy($node)
             );
 
             $response = $wings->getServer()->decompressArchive($server['uuid'], $file, $root);

--- a/backend/app/Services/Chatbot/Tools/DeleteAllocationTool.php
+++ b/backend/app/Services/Chatbot/Tools/DeleteAllocationTool.php
@@ -17,6 +17,7 @@
 
 namespace App\Services\Chatbot\Tools;
 
+use App\Helpers\WingsUrlHelper;
 use App\App;
 use App\Chat\Node;
 use App\Chat\Server;
@@ -149,7 +150,8 @@ class DeleteAllocationTool implements ToolInterface
                     $node['daemonListen'],
                     $node['scheme'],
                     $node['daemon_token'],
-                    30
+                    30,
+                    WingsUrlHelper::isBehindProxy($node)
                 );
 
                 $response = $wings->getServer()->syncServer($server['uuid']);

--- a/backend/app/Services/Chatbot/Tools/DeleteBackupTool.php
+++ b/backend/app/Services/Chatbot/Tools/DeleteBackupTool.php
@@ -17,6 +17,7 @@
 
 namespace App\Services\Chatbot\Tools;
 
+use App\Helpers\WingsUrlHelper;
 use App\App;
 use App\Chat\Node;
 use App\Chat\Backup;
@@ -153,7 +154,8 @@ class DeleteBackupTool implements ToolInterface
                 $node['daemonListen'],
                 $node['scheme'],
                 $node['daemon_token'],
-                30
+                30,
+                WingsUrlHelper::isBehindProxy($node)
             );
 
             $response = $wings->getServer()->deleteBackup($server['uuid'], $backup['uuid']);

--- a/backend/app/Services/Chatbot/Tools/DeleteFilesTool.php
+++ b/backend/app/Services/Chatbot/Tools/DeleteFilesTool.php
@@ -17,6 +17,7 @@
 
 namespace App\Services\Chatbot\Tools;
 
+use App\Helpers\WingsUrlHelper;
 use App\App;
 use App\Chat\Node;
 use App\Chat\Server;
@@ -128,7 +129,8 @@ class DeleteFilesTool implements ToolInterface
                 $node['daemonListen'],
                 $node['scheme'],
                 $node['daemon_token'],
-                30
+                30,
+                WingsUrlHelper::isBehindProxy($node)
             );
 
             $response = $wings->getServer()->deleteFiles($server['uuid'], $root, $files);

--- a/backend/app/Services/Chatbot/Tools/GetFileContentTool.php
+++ b/backend/app/Services/Chatbot/Tools/GetFileContentTool.php
@@ -17,6 +17,7 @@
 
 namespace App\Services\Chatbot\Tools;
 
+use App\Helpers\WingsUrlHelper;
 use App\Chat\Node;
 use App\Chat\Server;
 use App\Services\Wings\Wings;
@@ -104,7 +105,8 @@ class GetFileContentTool implements ToolInterface
                 $node['daemonListen'],
                 $node['scheme'],
                 $node['daemon_token'],
-                30
+                30,
+                WingsUrlHelper::isBehindProxy($node)
             );
 
             $response = $wings->getServer()->getFileContentsRaw($server['uuid'], $path, false);

--- a/backend/app/Services/Chatbot/Tools/GetFilesTool.php
+++ b/backend/app/Services/Chatbot/Tools/GetFilesTool.php
@@ -17,6 +17,7 @@
 
 namespace App\Services\Chatbot\Tools;
 
+use App\Helpers\WingsUrlHelper;
 use App\Chat\Node;
 use App\Chat\Server;
 use App\Services\Wings\Wings;
@@ -98,7 +99,8 @@ class GetFilesTool implements ToolInterface
                 $node['daemonListen'],
                 $node['scheme'],
                 $node['daemon_token'],
-                30
+                30,
+                WingsUrlHelper::isBehindProxy($node)
             );
 
             $response = $wings->getServer()->listDirectory($server['uuid'], $path);

--- a/backend/app/Services/Chatbot/Tools/GetServerFirewallRulesTool.php
+++ b/backend/app/Services/Chatbot/Tools/GetServerFirewallRulesTool.php
@@ -17,6 +17,7 @@
 
 namespace App\Services\Chatbot\Tools;
 
+use App\Helpers\WingsUrlHelper;
 use App\App;
 use App\Chat\Node;
 use App\Chat\Server;
@@ -104,7 +105,8 @@ class GetServerFirewallRulesTool implements ToolInterface
                 $node['daemonListen'],
                 $node['scheme'],
                 $node['daemon_token'],
-                10
+                10,
+                WingsUrlHelper::isBehindProxy($node)
             );
 
             $response = $wings->getServer()->getFirewallRules($server['uuid']);

--- a/backend/app/Services/Chatbot/Tools/GetServerStatusTool.php
+++ b/backend/app/Services/Chatbot/Tools/GetServerStatusTool.php
@@ -106,7 +106,7 @@ class GetServerStatusTool implements ToolInterface
                 $node['daemonListen'],
                 $node['scheme'],
                 $node['daemon_token'],
-                10 // 10 second timeout,
+                10, // 10 second timeout
                 WingsUrlHelper::isBehindProxy($node)
             );
 

--- a/backend/app/Services/Chatbot/Tools/GetServerStatusTool.php
+++ b/backend/app/Services/Chatbot/Tools/GetServerStatusTool.php
@@ -17,6 +17,7 @@
 
 namespace App\Services\Chatbot\Tools;
 
+use App\Helpers\WingsUrlHelper;
 use App\App;
 use App\Chat\Server;
 use App\Services\Wings\Wings;
@@ -105,7 +106,8 @@ class GetServerStatusTool implements ToolInterface
                 $node['daemonListen'],
                 $node['scheme'],
                 $node['daemon_token'],
-                10 // 10 second timeout
+                10 // 10 second timeout,
+                WingsUrlHelper::isBehindProxy($node)
             );
 
             $serverResponse = $wings->getServer()->getServer($server['uuid']);

--- a/backend/app/Services/Chatbot/Tools/PullFileTool.php
+++ b/backend/app/Services/Chatbot/Tools/PullFileTool.php
@@ -17,6 +17,7 @@
 
 namespace App\Services\Chatbot\Tools;
 
+use App\Helpers\WingsUrlHelper;
 use App\App;
 use App\Chat\Node;
 use App\Chat\Server;
@@ -131,7 +132,8 @@ class PullFileTool implements ToolInterface
                 $node['daemonListen'],
                 $node['scheme'],
                 $node['daemon_token'],
-                30
+                30,
+                WingsUrlHelper::isBehindProxy($node)
             );
 
             $response = $wings->getServer()->pullFile(

--- a/backend/app/Services/Chatbot/Tools/RenameFileTool.php
+++ b/backend/app/Services/Chatbot/Tools/RenameFileTool.php
@@ -17,6 +17,7 @@
 
 namespace App\Services\Chatbot\Tools;
 
+use App\Helpers\WingsUrlHelper;
 use App\App;
 use App\Chat\Node;
 use App\Chat\Server;
@@ -139,7 +140,8 @@ class RenameFileTool implements ToolInterface
                 $node['daemonListen'],
                 $node['scheme'],
                 $node['daemon_token'],
-                30
+                30,
+                WingsUrlHelper::isBehindProxy($node)
             );
 
             $response = $wings->getServer()->renameFiles($server['uuid'], $root, $files);

--- a/backend/app/Services/Chatbot/Tools/ServerPowerActionTool.php
+++ b/backend/app/Services/Chatbot/Tools/ServerPowerActionTool.php
@@ -17,6 +17,7 @@
 
 namespace App\Services\Chatbot\Tools;
 
+use App\Helpers\WingsUrlHelper;
 use App\App;
 use App\Chat\Node;
 use App\Chat\Server;
@@ -144,7 +145,8 @@ class ServerPowerActionTool implements ToolInterface
                 $node['daemonListen'],
                 $node['scheme'],
                 $node['daemon_token'],
-                30
+                30,
+                WingsUrlHelper::isBehindProxy($node)
             );
 
             $response = null;

--- a/backend/app/Services/Chatbot/Tools/SetPrimaryAllocationTool.php
+++ b/backend/app/Services/Chatbot/Tools/SetPrimaryAllocationTool.php
@@ -17,6 +17,7 @@
 
 namespace App\Services\Chatbot\Tools;
 
+use App\Helpers\WingsUrlHelper;
 use App\App;
 use App\Chat\Node;
 use App\Chat\Server;
@@ -140,7 +141,8 @@ class SetPrimaryAllocationTool implements ToolInterface
                     $node['daemonListen'],
                     $node['scheme'],
                     $node['daemon_token'],
-                    30
+                    30,
+                    WingsUrlHelper::isBehindProxy($node)
                 );
 
                 $response = $wings->getServer()->syncServer($server['uuid']);

--- a/backend/app/Services/Chatbot/Tools/WriteFileTool.php
+++ b/backend/app/Services/Chatbot/Tools/WriteFileTool.php
@@ -17,6 +17,7 @@
 
 namespace App\Services\Chatbot\Tools;
 
+use App\Helpers\WingsUrlHelper;
 use App\App;
 use App\Chat\Node;
 use App\Chat\Server;
@@ -128,7 +129,8 @@ class WriteFileTool implements ToolInterface
                 $node['daemonListen'],
                 $node['scheme'],
                 $node['daemon_token'],
-                30
+                30,
+                WingsUrlHelper::isBehindProxy($node)
             );
 
             $response = $wings->getServer()->writeFile($server['uuid'], $path, $content);

--- a/backend/app/Services/FeatherZeroTrust/SuspensionService.php
+++ b/backend/app/Services/FeatherZeroTrust/SuspensionService.php
@@ -17,6 +17,7 @@
 
 namespace App\Services\FeatherZeroTrust;
 
+use App\Helpers\WingsUrlHelper;
 use App\App;
 use App\Chat\Node;
 use App\Chat\User;
@@ -95,7 +96,8 @@ class SuspensionService
                 $node['daemonListen'],
                 $node['scheme'],
                 $node['daemon_token'],
-                30
+                30,
+                WingsUrlHelper::isBehindProxy($node)
             );
 
             $response = $wings->getServer()->killServer($serverUuid);

--- a/backend/app/Services/Server/LifecycleHookExecutorService.php
+++ b/backend/app/Services/Server/LifecycleHookExecutorService.php
@@ -17,6 +17,7 @@
 
 namespace App\Services\Server;
 
+use App\Helpers\WingsUrlHelper;
 use App\App;
 use GuzzleHttp\Client;
 use App\Chat\ServerActivity;
@@ -256,7 +257,8 @@ class LifecycleHookExecutorService
             $node['daemonListen'],
             $node['scheme'],
             $node['daemon_token'],
-            30
+            30,
+            WingsUrlHelper::isBehindProxy($node)
         );
         $response = $wings->getServer()->sendCommands($server['uuid'], [$command]);
         if (!$response->isSuccessful()) {

--- a/backend/app/Services/UserDataExport/UserDataExportService.php
+++ b/backend/app/Services/UserDataExport/UserDataExportService.php
@@ -779,7 +779,8 @@ class UserDataExportService
                 (int) $node['daemonListen'],
                 $node['scheme'],
                 $node['daemon_token'],
-                30
+                30,
+                WingsUrlHelper::isBehindProxy($node)
             );
             $response = $wings->getServer()->createBackup((string) $server['uuid'], 'wings', $backupUuid, '[]');
 


### PR DESCRIPTION
Turns out this bug is way bigger than I first thought. Opened this originally just for WingsAdminController, but it's actually every single new Wings(...) call in the codebase except Wings::fromNode() - 62 call sites across 30 files (server controllers, backup/power/logs controllers, node controllers, every chatbot tool, transfer status, etc).

All of them skip the 6th constructor arg and default behindProxy to false, so anything that talks to a proxied node hits the raw daemon port instead of going through the proxy. Was breaking server creation, backups, power actions, chatbot tools, basically everything node-related once behind_proxy is actually set to true.

Fixed the same way everywhere - added WingsUrlHelper::isBehindProxy($node) as the 6th arg, matching whatever the node variable is called in that spot ($node, $nodeInfo, $sourceNode, $destinationNode).

Tested on my own instance behind Caddy, server creation/backups/power actions all work now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved node operations for nodes configured behind proxies, so administrator workflows (system utilization, Docker management, module enable/disable, and configuration updates) connect with the correct proxy-aware settings.
  * Updated user-facing actions and automation (status checks, logs, power actions, backups/restore, file operations, and container commands) to use the appropriate proxy-aware connection handling for each target node.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->