### PR TITLE
fix(webspace-files): unwrap daemon-wrapped data payload to prevent double-nesting

### DIFF
--- a/backend/app/Controllers/User/WebSpaces/WebSpaceFilesController.php
+++ b/backend/app/Controllers/User/WebSpaces/WebSpaceFilesController.php
@@ -1104,7 +1104,24 @@ class WebSpaceFilesController
             $this->logFileActivity($resolved, $activityEvent, $activityMeta);
         }
 
+        // FeatherQuilld daemon endpoints are inconsistent: some return a bare payload
+        // (e.g. {"ok": true}, or {"ok": true, "data": {"path": ...}}), others wrap their
+        // *entire* payload in a "data" key with nothing else alongside it, as a list or object
+        // (list/search/pull-jobs return {"data": [...]} or {"data": {"entries": [...]}}).
+        // ApiResponse::success() always wraps whatever we pass it in another "data" key, so
+        // blindly forwarding the full daemon body for the latter group used to produce
+        // {"data": {"data": [...]}} — the frontend reads response.data and got the wrapper
+        // object instead of the actual list, showing "No Files Found" even though the daemon
+        // returned real entries. Unwrap the daemon's own "data" key only when it is the sole
+        // top-level key AND itself an array/object, so there is always exactly one "data"
+        // envelope for those endpoints. Endpoints that pair "data" with sibling keys (e.g.
+        // "ok") keep both intact, and endpoints whose "data" value is a bare scalar (e.g.
+        // files/contents returning {"data": "<file text>"}) are left untouched — the frontend
+        // already expects that shape as response.data.data for the file editor.
         $body = is_array($daemon['body']) ? $daemon['body'] : ['data' => $daemon['body']];
+        if (array_keys($body) === ['data'] && is_array($body['data'])) {
+            $body = $body['data'];
+        }
 
         return ApiResponse::success($body, 'OK', 200);
     }


### PR DESCRIPTION
## Summary

Fixes the WebSpace file manager showing "No Files Found" even when the
WebSpace actually contains files.

## Root cause

`WebSpaceFilesController::daemonResponse()` always forwards the FeatherQuilld
daemon's raw response body into `ApiResponse::success()`. FeatherQuilld
daemon endpoints are inconsistent in their own response shape:

- Some return a bare payload, e.g. `{"ok": true}` or
  `{"ok": true, "data": {"path": "..."}}`.
- Others (list / search / pull-jobs) wrap their *entire* payload in a single
  `"data"` key with nothing else alongside it, e.g. `{"data": [...]}` or
  `{"data": {"entries": [...], "total": 4, "page": 1, "per_page": 250}}`.

`ApiResponse::success()` always wraps whatever it's given in another
top-level `"data"` key. For the second group above this produces a doubly
nested response: `{"data": {"data": [...]}}`. The frontend reads
`response.data` expecting the actual list/object directly, so it received
the wrapper object instead — resulting in an empty-looking file manager even
though the daemon returned real file entries.

## Fix

Unwrap the daemon's own `"data"` key in `daemonResponse()`, but only when:

- it is the **sole** top-level key in the daemon body, and
- its value is itself an array/object.

This collapses the double envelope for list/search/pull-jobs-style
responses while leaving untouched:

- endpoints that pair `"data"` with sibling keys (e.g. `{"ok": true, "data": {...}}`)
- endpoints whose `"data"` value is a bare scalar (e.g. `files/contents`
  returning `{"data": "<file text>"}`), which the frontend already reads as
  `response.data.data` for the file editor.

## Testing

Reproduced and verified live against a real FeatherQuilld node + WebSpace:

- Before: `GET /api/user/webspaces/{uuid}/files/list?directory=/&page=1&per_page=250`
  returned `{"data": {"data": {"entries": [...]}}}` and the file manager UI
  showed "No Files Found" for a WebSpace with 4 real files.
- After: same request returns `{"data": {"entries": [...], "total": 4, ...}}`
  and the file manager correctly lists all files.
- Verified `files/contents` (file editor) still works correctly (unaffected,
  since its daemon body's `"data"` value is a scalar string).
- Verified `files/create-directory` (`{"ok": true}` shape) still works
  correctly and is unaffected by the unwrap condition.
- Verified `files/pull-jobs` (`{"data": {"downloads": []}}` shape) unwraps
  correctly to `{"data": {"downloads": []}}` with no double nesting.

No automated test suite changes; this is a minimal, scoped fix to a single
private helper method used by every `WebSpaceFilesController` daemon-backed
endpoint.
