### PR TITLE
security: fix auth account enumeration and add per-account lockout

### DIFF
--- a/backend/app/Controllers/User/Auth/ForgotPasswordController.php
+++ b/backend/app/Controllers/User/Auth/ForgotPasswordController.php
@@ -121,6 +121,12 @@ class ForgotPasswordController
             return ApiResponse::error('Invalid email address', 'INVALID_EMAIL_ADDRESS');
         }
 
+        // Generic response message used regardless of whether the account exists.
+        // Returning a distinct error for unknown emails allows trivial account
+        // enumeration (see security audit), so we always respond the same way
+        // and only perform the reset side-effects when the account is real.
+        $genericSuccess = static fn () => ApiResponse::success(null, 'If an account with that email exists, we have sent a password reset link', 200);
+
         // Login user
         $userInfo = User::getUserByEmail($data['email']);
         if ($userInfo == null) {
@@ -137,7 +143,9 @@ class ForgotPasswordController
                 );
             }
 
-            return ApiResponse::error('Email does not exist', 'EMAIL_DOES_NOT_EXIST');
+            // Do not reveal whether the email exists: respond identically to the
+            // success path instead of returning EMAIL_DOES_NOT_EXIST.
+            return $genericSuccess();
         }
         $resetToken = bin2hex(random_bytes(32));
 
@@ -182,9 +190,11 @@ class ForgotPasswordController
                 'ip_address' => CloudFlareRealIP::getRealIP(),
             ]);
 
-            return ApiResponse::success(null, 'We have sent you an email to reset your password', 200);
+            return $genericSuccess();
         }
 
-        return ApiResponse::error('Failed to update user', 'FAILED_TO_UPDATE_USER');
+        // Even on internal failure, do not leak account existence via a different
+        // response than the generic one.
+        return $genericSuccess();
     }
 }

--- a/backend/app/Controllers/User/Auth/LoginController.php
+++ b/backend/app/Controllers/User/Auth/LoginController.php
@@ -27,6 +27,7 @@ use OpenApi\Attributes as OA;
 use App\Config\ConfigInterface;
 use App\Helpers\UserDeviceTracker;
 use App\CloudFlare\CloudFlareRealIP;
+use App\Helpers\AccountLockoutHelper;
 use App\Plugins\Events\Events\AuthEvent;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -203,7 +204,13 @@ class LoginController
                 );
             }
 
-            return ApiResponse::error('Invalid username or email address', 'INVALID_USERNAME_OR_EMAIL');
+            // Run a dummy password_verify against a fixed bcrypt hash so that the
+            // response timing for "unknown user" is close to the "wrong password"
+            // path below, and return the same generic error/code in both cases
+            // to avoid leaking whether an account exists (account enumeration).
+            password_verify($data['password'], '$2y$12$hKs6swAiRf/kPjRDC6xEWun.GMew67fz3jytWTurlD/p4Ag7xyCf6');
+
+            return ApiResponse::error('Invalid username, email address, or password', 'INVALID_CREDENTIALS');
         }
         if ($userInfo['banned'] == 'true') {
             // Emit login failed event
@@ -224,6 +231,20 @@ class LoginController
 
         if (($userInfo['deleted'] ?? 'false') === 'true') {
             return ApiResponse::error('Account is deleted', 'ACCOUNT_DELETED', 403);
+        }
+
+        // Per-account lockout: independent of IP-based rate limiting so that
+        // rotating IPs (proxy/botnet) cannot be used to brute-force a single
+        // known account's password.
+        $lockoutId = 'login:' . $userInfo['uuid'];
+        $lockoutRemaining = AccountLockoutHelper::getLockoutRemaining($lockoutId);
+        if ($lockoutRemaining > 0) {
+            return ApiResponse::error(
+                'Too many failed login attempts. Try again in ' . ceil($lockoutRemaining / 60) . ' minute(s).',
+                'ACCOUNT_LOCKED',
+                429,
+                ['retry_after' => $lockoutRemaining]
+            );
         }
 
         // When OIDC has disabled local login, only allow local login for admins (before password check to avoid leaking valid-credential signal)
@@ -247,8 +268,14 @@ class LoginController
                 );
             }
 
-            return ApiResponse::error('Invalid password', 'INVALID_PASSWORD');
+            AccountLockoutHelper::recordFailure($lockoutId);
+
+            return ApiResponse::error('Invalid username, email address, or password', 'INVALID_CREDENTIALS');
         }
+
+        // Successful password check: clear any prior failure count for this account.
+        AccountLockoutHelper::clear($lockoutId);
+
 
         $requiresEmailVerification = $config->getSetting(ConfigInterface::REGISTRATION_REQUIRE_EMAIL_VERIFICATION, 'false') === 'true';
         $isEmailVerified = !isset($userInfo['mail_verify']) || $userInfo['mail_verify'] === null || trim((string) $userInfo['mail_verify']) === '';

--- a/backend/app/Controllers/User/Auth/TwoFactorController.php
+++ b/backend/app/Controllers/User/Auth/TwoFactorController.php
@@ -25,6 +25,7 @@ use OpenApi\Attributes as OA;
 use App\Config\ConfigInterface;
 use PragmaRX\Google2FA\Google2FA;
 use App\CloudFlare\CloudFlareRealIP;
+use App\Helpers\AccountLockoutHelper;
 use App\Plugins\Events\Events\AuthEvent;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -266,6 +267,21 @@ class TwoFactorController
         if (!$userInfo || $userInfo['two_fa_enabled'] !== 'true') {
             return ApiResponse::error('2FA not enabled', 'two_fa_NOT_ENABLED');
         }
+
+        // Per-account lockout for 2FA verification: a 6-digit TOTP code has
+        // only 1,000,000 possible values, so this must be tighter than the
+        // login password lockout to prevent brute-forcing it via IP rotation.
+        $lockoutId = '2fa:' . $userInfo['uuid'];
+        $lockoutRemaining = AccountLockoutHelper::getLockoutRemaining($lockoutId);
+        if ($lockoutRemaining > 0) {
+            return ApiResponse::error(
+                'Too many failed 2FA attempts. Try again in ' . ceil($lockoutRemaining / 60) . ' minute(s).',
+                'ACCOUNT_LOCKED',
+                429,
+                ['retry_after' => $lockoutRemaining]
+            );
+        }
+
         $google2fa = new Google2FA();
         if (!$google2fa->verifyKey($userInfo['two_fa_key'], $data['code'])) {
             // Emit 2FA failed event
@@ -280,8 +296,12 @@ class TwoFactorController
                 );
             }
 
+            AccountLockoutHelper::recordFailure($lockoutId, maxAttempts: 5, lockoutSeconds: 900);
+
             return ApiResponse::error('Invalid 2FA code', 'INVALID_CODE');
         }
+
+        AccountLockoutHelper::clear($lockoutId);
 
         // Logging in cancels a pending self-service account deletion request
         if (\App\Services\User\UserDeletionService::hasPendingDeletion($userInfo)) {

--- a/backend/app/Helpers/AccountLockoutHelper.php
+++ b/backend/app/Helpers/AccountLockoutHelper.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * This file is part of FeatherPanel.
+ *
+ * Copyright (C) 2025 MythicalSystems Studios
+ * Copyright (C) 2025 FeatherPanel Contributors
+ * Copyright (C) 2025 Cassian Gherman (aka NaysKutzu)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See the LICENSE file or <https://www.gnu.org/licenses/>.
+ */
+
+namespace App\Helpers;
+
+use App\App;
+
+/**
+ * Per-account failed authentication tracking, independent of the existing
+ * per-IP rate limiter. This closes the gap where an attacker can rotate IPs
+ * (proxy/botnet) to bypass IP-based rate limiting and still brute-force a
+ * single known account (login password or 2FA code).
+ *
+ * Fails open (does not block login) if Redis is unavailable, matching the
+ * behavior of RateLimitMiddleware, so a Redis outage never locks everyone out.
+ */
+class AccountLockoutHelper
+{
+    /** Failed attempts allowed before lockout kicks in. */
+    private const MAX_ATTEMPTS = 10;
+
+    /** Lockout duration in seconds once MAX_ATTEMPTS is reached. */
+    private const LOCKOUT_SECONDS = 900; // 15 minutes
+
+    /** Window in seconds during which failed attempts are counted. */
+    private const ATTEMPT_WINDOW_SECONDS = 900; // 15 minutes
+
+    /**
+     * Returns the remaining lockout time in seconds, or 0 if the identifier
+     * (e.g. "login:<user_uuid>" or "2fa:<user_uuid>") is not currently locked.
+     */
+    public static function getLockoutRemaining(string $identifier): int
+    {
+        $redis = self::getRedis();
+        if ($redis === null) {
+            return 0;
+        }
+
+        $ttl = $redis->ttl(self::lockKey($identifier));
+
+        return $ttl > 0 ? $ttl : 0;
+    }
+
+    /**
+     * Record a failed attempt for the identifier. If this pushes the count
+     * over $maxAttempts within the attempt window, the account is locked for
+     * $lockoutSeconds.
+     */
+    public static function recordFailure(string $identifier, ?int $maxAttempts = null, ?int $lockoutSeconds = null): void
+    {
+        $redis = self::getRedis();
+        if ($redis === null) {
+            return;
+        }
+
+        $maxAttempts ??= self::MAX_ATTEMPTS;
+        $lockoutSeconds ??= self::LOCKOUT_SECONDS;
+
+        $countKey = self::countKey($identifier);
+        $count = $redis->incr($countKey);
+        if ($count === 1) {
+            $redis->expire($countKey, self::ATTEMPT_WINDOW_SECONDS);
+        }
+
+        if ($count >= $maxAttempts) {
+            $redis->setex(self::lockKey($identifier), $lockoutSeconds, '1');
+        }
+    }
+
+    /**
+     * Clear failure tracking for the identifier (call on successful auth).
+     */
+    public static function clear(string $identifier): void
+    {
+        $redis = self::getRedis();
+        if ($redis === null) {
+            return;
+        }
+
+        $redis->del([self::countKey($identifier), self::lockKey($identifier)]);
+    }
+
+    private static function countKey(string $identifier): string
+    {
+        return 'account_lockout:count:' . $identifier;
+    }
+
+    private static function lockKey(string $identifier): string
+    {
+        return 'account_lockout:locked:' . $identifier;
+    }
+
+    private static function getRedis(): ?\Redis
+    {
+        try {
+            $app = App::getInstance(true);
+
+            return $app->getRedisConnection();
+        } catch (\Throwable $e) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Found during an internal security review of the authentication flow.

1. **Account enumeration on forgot-password**: `ForgotPasswordController` returned `EMAIL_DOES_NOT_EXIST` for unknown emails, letting an attacker enumerate the entire user base (including admins) by scripting requests. Now returns an identical generic response whether or not the account exists.
2. **Account enumeration on login**: `LoginController` distinguished `INVALID_USERNAME_OR_EMAIL` vs `INVALID_PASSWORD`. Unified into a single `INVALID_CREDENTIALS` response, plus a dummy `password_verify()` call on the unknown-user path to reduce the timing gap between the two branches.
3. **No per-account lockout**: rate limiting was IP-only (`RateLimitMiddleware`), so credential stuffing / 2FA brute-forcing could bypass it entirely via IP rotation (proxy/botnet). Added a new `AccountLockoutHelper` (Redis-backed, fails open if Redis is unavailable - consistent with the existing rate limiter) and wired it into both login (10 attempts / 15 min) and 2FA verification (5 attempts / 15 min, tighter since a 6-digit TOTP code has a much smaller keyspace).

## Testing

Tested live against a running instance:
- Forgot-password with a non-existent email now returns the same generic success message as a real email.
- Login with an unknown username and login with a known username + wrong password both return the same `INVALID_CREDENTIALS` error/status.
- Triggering repeated failed logins on a real account correctly returns `ACCOUNT_LOCKED` with a `retry_after` value, and normal login resumes after the lockout key is cleared.
- `php -l` clean on all changed/added files.

## Notes

- Lockout is per-account (keyed by user UUID), separate from the existing per-IP `RateLimitMiddleware`, so both layers apply together.
- Fails open if Redis is down, matching existing rate-limiter behavior, so a Redis outage cannot lock everyone out or become a DoS vector against login availability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Added account lockout protection for repeated failed login and two-factor authentication attempts.
  * Locked accounts receive retry information and temporary access restrictions.
  * Login failures now use a generic message to avoid revealing whether an account exists.
  * Password reset requests now show a generic confirmation message, regardless of whether the email is registered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->