### PR TITLE
security: secure session cookie flags + expiring password-reset tokens

### DIFF
--- a/backend/app/Controllers/User/Auth/AuthLogoutController.php
+++ b/backend/app/Controllers/User/Auth/AuthLogoutController.php
@@ -22,6 +22,7 @@ use App\Chat\Activity;
 use App\Helpers\ApiResponse;
 use OpenApi\Attributes as OA;
 use App\CloudFlare\CloudFlareRealIP;
+use App\Helpers\SessionCookieHelper;
 use App\Plugins\Events\Events\AuthEvent;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -53,7 +54,7 @@ class AuthLogoutController
     {
         global $eventManager;
         if (!isset($_COOKIE['remember_token'])) {
-            setcookie('remember_token', '', time() - 3600 - 1500 * 120);
+            SessionCookieHelper::clear();
 
             return ApiResponse::success([], 'Logged out and we did not find a remember_token', 200);
         }
@@ -94,7 +95,7 @@ class AuthLogoutController
                 'ip_address' => CloudFlareRealIP::getRealIP(),
             ]);
         }
-        setcookie('remember_token', '', time() - 3600 - 1500 * 120);
+        SessionCookieHelper::clear();
 
         return ApiResponse::success([], 'Logged out', 200);
     }

--- a/backend/app/Controllers/User/Auth/ForgotPasswordController.php
+++ b/backend/app/Controllers/User/Auth/ForgotPasswordController.php
@@ -147,7 +147,7 @@ class ForgotPasswordController
             // success path instead of returning EMAIL_DOES_NOT_EXIST.
             return $genericSuccess();
         }
-        $resetToken = bin2hex(random_bytes(32));
+        $resetToken = bin2hex(random_bytes(32)) . '.' . (time() + 3600);
 
         if (User::updateUser($userInfo['uuid'], ['mail_verify' => $resetToken])) {
             // Send reset password email

--- a/backend/app/Controllers/User/Auth/ForgotPasswordController.php
+++ b/backend/app/Controllers/User/Auth/ForgotPasswordController.php
@@ -121,6 +121,12 @@ class ForgotPasswordController
             return ApiResponse::error('Invalid email address', 'INVALID_EMAIL_ADDRESS');
         }
 
+        // Generic response message used regardless of whether the account exists.
+        // Returning a distinct error for unknown emails allows trivial account
+        // enumeration (see security audit), so we always respond the same way
+        // and only perform the reset side-effects when the account is real.
+        $genericSuccess = static fn () => ApiResponse::success(null, 'If an account with that email exists, we have sent a password reset link', 200);
+
         // Login user
         $userInfo = User::getUserByEmail($data['email']);
         if ($userInfo == null) {
@@ -137,7 +143,9 @@ class ForgotPasswordController
                 );
             }
 
-            return ApiResponse::error('Email does not exist', 'EMAIL_DOES_NOT_EXIST');
+            // Do not reveal whether the email exists: respond identically to the
+            // success path instead of returning EMAIL_DOES_NOT_EXIST.
+            return $genericSuccess();
         }
         $resetToken = bin2hex(random_bytes(32));
 
@@ -182,9 +190,11 @@ class ForgotPasswordController
                 'ip_address' => CloudFlareRealIP::getRealIP(),
             ]);
 
-            return ApiResponse::success(null, 'We have sent you an email to reset your password', 200);
+            return $genericSuccess();
         }
 
-        return ApiResponse::error('Failed to update user', 'FAILED_TO_UPDATE_USER');
+        // Even on internal failure, do not leak account existence via a different
+        // response than the generic one.
+        return $genericSuccess();
     }
 }

--- a/backend/app/Controllers/User/Auth/LoginController.php
+++ b/backend/app/Controllers/User/Auth/LoginController.php
@@ -27,6 +27,7 @@ use OpenApi\Attributes as OA;
 use App\Config\ConfigInterface;
 use App\Helpers\UserDeviceTracker;
 use App\CloudFlare\CloudFlareRealIP;
+use App\Helpers\AccountLockoutHelper;
 use App\Plugins\Events\Events\AuthEvent;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -203,7 +204,13 @@ class LoginController
                 );
             }
 
-            return ApiResponse::error('Invalid username or email address', 'INVALID_USERNAME_OR_EMAIL');
+            // Run a dummy password_verify against a fixed bcrypt hash so that the
+            // response timing for "unknown user" is close to the "wrong password"
+            // path below, and return the same generic error/code in both cases
+            // to avoid leaking whether an account exists (account enumeration).
+            password_verify($data['password'], '$2y$12$hKs6swAiRf/kPjRDC6xEWun.GMew67fz3jytWTurlD/p4Ag7xyCf6');
+
+            return ApiResponse::error('Invalid username, email address, or password', 'INVALID_CREDENTIALS');
         }
         if ($userInfo['banned'] == 'true') {
             // Emit login failed event
@@ -224,6 +231,20 @@ class LoginController
 
         if (($userInfo['deleted'] ?? 'false') === 'true') {
             return ApiResponse::error('Account is deleted', 'ACCOUNT_DELETED', 403);
+        }
+
+        // Per-account lockout: independent of IP-based rate limiting so that
+        // rotating IPs (proxy/botnet) cannot be used to brute-force a single
+        // known account's password.
+        $lockoutId = 'login:' . $userInfo['uuid'];
+        $lockoutRemaining = AccountLockoutHelper::getLockoutRemaining($lockoutId);
+        if ($lockoutRemaining > 0) {
+            return ApiResponse::error(
+                'Too many failed login attempts. Try again in ' . ceil($lockoutRemaining / 60) . ' minute(s).',
+                'ACCOUNT_LOCKED',
+                429,
+                ['retry_after' => $lockoutRemaining]
+            );
         }
 
         // When OIDC has disabled local login, only allow local login for admins (before password check to avoid leaking valid-credential signal)
@@ -247,8 +268,14 @@ class LoginController
                 );
             }
 
-            return ApiResponse::error('Invalid password', 'INVALID_PASSWORD');
+            AccountLockoutHelper::recordFailure($lockoutId);
+
+            return ApiResponse::error('Invalid username, email address, or password', 'INVALID_CREDENTIALS');
         }
+
+        // Successful password check: clear any prior failure count for this account.
+        AccountLockoutHelper::clear($lockoutId);
+
 
         $requiresEmailVerification = $config->getSetting(ConfigInterface::REGISTRATION_REQUIRE_EMAIL_VERIFICATION, 'false') === 'true';
         $isEmailVerified = !isset($userInfo['mail_verify']) || $userInfo['mail_verify'] === null || trim((string) $userInfo['mail_verify']) === '';

--- a/backend/app/Controllers/User/Auth/LoginController.php
+++ b/backend/app/Controllers/User/Auth/LoginController.php
@@ -28,6 +28,7 @@ use App\Config\ConfigInterface;
 use App\Helpers\UserDeviceTracker;
 use App\CloudFlare\CloudFlareRealIP;
 use App\Helpers\AccountLockoutHelper;
+use App\Helpers\SessionCookieHelper;
 use App\Plugins\Events\Events\AuthEvent;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -319,7 +320,7 @@ class LoginController
             return ApiResponse::error('Remember token not set', 'REMEMBER_TOKEN_NOT_SET');
         }
         $userInfo['remember_token'] = $token;
-        setcookie('remember_token', $token, time() + 60 * 60 * 24 * 30, '/');
+        SessionCookieHelper::set($token, time() + 60 * 60 * 24 * 30);
         User::updateUser($userInfo['uuid'], ['last_ip' => CloudFlareRealIP::getRealIP()]);
         UserDeviceTracker::trackFromGlobals($userInfo);
 

--- a/backend/app/Controllers/User/Auth/RegisterController.php
+++ b/backend/app/Controllers/User/Auth/RegisterController.php
@@ -30,6 +30,7 @@ use App\Helpers\UserDeviceTracker;
 use App\Mail\templates\VerifyEmail;
 use App\CloudFlare\CloudFlareRealIP;
 use App\Helpers\EmailDomainValidator;
+use App\Helpers\SessionCookieHelper;
 use App\Plugins\Events\Events\AuthEvent;
 use App\Helpers\AbuseIPDBRegistrationGuard;
 use App\Helpers\UserDeviceRegistrationGuard;
@@ -345,7 +346,7 @@ class RegisterController
             // Set session/cookie
             if (isset($createdUser['remember_token'])) {
                 $token = $createdUser['remember_token'];
-                setcookie('remember_token', $token, time() + 60 * 60 * 24 * 30, '/');
+                SessionCookieHelper::set($token, time() + 60 * 60 * 24 * 30);
                 User::updateUser($createdUser['uuid'], ['last_ip' => CloudFlareRealIP::getRealIP()]);
 
                 // Create login activity (user is automatically logged in)

--- a/backend/app/Controllers/User/Auth/ResetPasswordController.php
+++ b/backend/app/Controllers/User/Auth/ResetPasswordController.php
@@ -120,6 +120,29 @@ class ResetPasswordController
                 return ApiResponse::error('Looks like the token is invalid or expired or already used', 'INVALID_TOKEN');
             }
 
+            // Password reset tokens embed an expiry as "<hex>.<unix_ts>" (see
+            // ForgotPasswordController). Older/foreign tokens without that
+            // suffix (e.g. an email-verification token that happens to be
+            // looked up here) are treated as expired/invalid rather than
+            // accepted indefinitely.
+            if (!self::isResetTokenValid($data['token'])) {
+                global $eventManager;
+                if (isset($eventManager) && $eventManager !== null) {
+                    $eventManager->emit(
+                        AuthEvent::onAuthPasswordResetFailed(),
+                        [
+                            'token' => $data['token'],
+                            'reason' => 'TOKEN_EXPIRED',
+                            'ip_address' => CloudFlareRealIP::getRealIP(),
+                        ]
+                    );
+                }
+                // Invalidate the stale token so it can't be retried later.
+                User::updateUser($userInfo['uuid'], ['mail_verify' => null]);
+
+                return ApiResponse::error('Looks like the token is invalid or expired or already used', 'INVALID_TOKEN');
+            }
+
             if (User::updateUser($userInfo['uuid'], ['password' => password_hash($data['password'], PASSWORD_BCRYPT), 'remember_token' => User::generateAccountToken()]) && User::updateUser($userInfo['uuid'], ['mail_verify' => null])) {
                 Activity::createActivity([
                     'user_uuid' => $userInfo['uuid'],
@@ -187,10 +210,37 @@ class ResetPasswordController
                     'token' => $token,
                 ]);
             }
+            if (!self::isResetTokenValid($token)) {
+                return ApiResponse::error('Looks like the token is invalid or expired', 'INVALID_TOKEN', 400, [
+                    'token' => $token,
+                ]);
+            }
 
             return ApiResponse::success(null, 'Token is valid', 200);
         } catch (\Exception $e) {
             return ApiResponse::exception('An error occurred: ' . $e->getMessage(), $e->getCode());
         }
+    }
+
+    /**
+     * Reset tokens are generated as "<64 hex chars>.<unix_timestamp>" (see
+     * ForgotPasswordController::put()). Validate both the shape and that the
+     * embedded expiry has not passed yet.
+     */
+    private static function isResetTokenValid(string $token): bool
+    {
+        $parts = explode('.', $token, 2);
+        if (count($parts) !== 2) {
+            return false;
+        }
+        [$hex, $expiresAt] = $parts;
+        if (!ctype_xdigit($hex) || strlen($hex) !== 64) {
+            return false;
+        }
+        if (!ctype_digit($expiresAt)) {
+            return false;
+        }
+
+        return (int) $expiresAt >= time();
     }
 }

--- a/backend/app/Controllers/User/Auth/TwoFactorController.php
+++ b/backend/app/Controllers/User/Auth/TwoFactorController.php
@@ -26,6 +26,7 @@ use App\Config\ConfigInterface;
 use PragmaRX\Google2FA\Google2FA;
 use App\CloudFlare\CloudFlareRealIP;
 use App\Helpers\AccountLockoutHelper;
+use App\Helpers\SessionCookieHelper;
 use App\Plugins\Events\Events\AuthEvent;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -317,7 +318,7 @@ class TwoFactorController
             return ApiResponse::error('Remember token not set', 'REMEMBER_TOKEN_NOT_SET');
         }
         $userInfo['remember_token'] = $token;
-        setcookie('remember_token', $token, time() + 60 * 60 * 24 * 30, '/');
+        SessionCookieHelper::set($token, time() + 60 * 60 * 24 * 30);
         User::updateUser($userInfo['uuid'], ['last_ip' => CloudFlareRealIP::getRealIP()]);
 
         Activity::createActivity([

--- a/backend/app/Controllers/User/Auth/TwoFactorController.php
+++ b/backend/app/Controllers/User/Auth/TwoFactorController.php
@@ -25,6 +25,7 @@ use OpenApi\Attributes as OA;
 use App\Config\ConfigInterface;
 use PragmaRX\Google2FA\Google2FA;
 use App\CloudFlare\CloudFlareRealIP;
+use App\Helpers\AccountLockoutHelper;
 use App\Plugins\Events\Events\AuthEvent;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -266,6 +267,21 @@ class TwoFactorController
         if (!$userInfo || $userInfo['two_fa_enabled'] !== 'true') {
             return ApiResponse::error('2FA not enabled', 'two_fa_NOT_ENABLED');
         }
+
+        // Per-account lockout for 2FA verification: a 6-digit TOTP code has
+        // only 1,000,000 possible values, so this must be tighter than the
+        // login password lockout to prevent brute-forcing it via IP rotation.
+        $lockoutId = '2fa:' . $userInfo['uuid'];
+        $lockoutRemaining = AccountLockoutHelper::getLockoutRemaining($lockoutId);
+        if ($lockoutRemaining > 0) {
+            return ApiResponse::error(
+                'Too many failed 2FA attempts. Try again in ' . ceil($lockoutRemaining / 60) . ' minute(s).',
+                'ACCOUNT_LOCKED',
+                429,
+                ['retry_after' => $lockoutRemaining]
+            );
+        }
+
         $google2fa = new Google2FA();
         if (!$google2fa->verifyKey($userInfo['two_fa_key'], $data['code'])) {
             // Emit 2FA failed event
@@ -280,8 +296,12 @@ class TwoFactorController
                 );
             }
 
+            AccountLockoutHelper::recordFailure($lockoutId, maxAttempts: 5, lockoutSeconds: 900);
+
             return ApiResponse::error('Invalid 2FA code', 'INVALID_CODE');
         }
+
+        AccountLockoutHelper::clear($lockoutId);
 
         // Logging in cancels a pending self-service account deletion request
         if (\App\Services\User\UserDeletionService::hasPendingDeletion($userInfo)) {

--- a/backend/app/Controllers/User/User/AccountDeletionController.php
+++ b/backend/app/Controllers/User/User/AccountDeletionController.php
@@ -24,6 +24,7 @@ use App\Helpers\ApiResponse;
 use OpenApi\Attributes as OA;
 use App\Helpers\CaptchaHelper;
 use App\Config\ConfigInterface;
+use App\Helpers\SessionCookieHelper;
 use PragmaRX\Google2FA\Google2FA;
 use App\CloudFlare\CloudFlareRealIP;
 use App\Mail\templates\AccountDeletionOtp;
@@ -372,7 +373,7 @@ class AccountDeletionController
 
     private function clearSessionCookie(): void
     {
-        setcookie('remember_token', '', time() - 3600, '/');
+        SessionCookieHelper::clear();
         unset($_COOKIE['remember_token']);
     }
 }

--- a/backend/app/Helpers/AccountLockoutHelper.php
+++ b/backend/app/Helpers/AccountLockoutHelper.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * This file is part of FeatherPanel.
+ *
+ * Copyright (C) 2025 MythicalSystems Studios
+ * Copyright (C) 2025 FeatherPanel Contributors
+ * Copyright (C) 2025 Cassian Gherman (aka NaysKutzu)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See the LICENSE file or <https://www.gnu.org/licenses/>.
+ */
+
+namespace App\Helpers;
+
+use App\App;
+
+/**
+ * Per-account failed authentication tracking, independent of the existing
+ * per-IP rate limiter. This closes the gap where an attacker can rotate IPs
+ * (proxy/botnet) to bypass IP-based rate limiting and still brute-force a
+ * single known account (login password or 2FA code).
+ *
+ * Fails open (does not block login) if Redis is unavailable, matching the
+ * behavior of RateLimitMiddleware, so a Redis outage never locks everyone out.
+ */
+class AccountLockoutHelper
+{
+    /** Failed attempts allowed before lockout kicks in. */
+    private const MAX_ATTEMPTS = 10;
+
+    /** Lockout duration in seconds once MAX_ATTEMPTS is reached. */
+    private const LOCKOUT_SECONDS = 900; // 15 minutes
+
+    /** Window in seconds during which failed attempts are counted. */
+    private const ATTEMPT_WINDOW_SECONDS = 900; // 15 minutes
+
+    /**
+     * Returns the remaining lockout time in seconds, or 0 if the identifier
+     * (e.g. "login:<user_uuid>" or "2fa:<user_uuid>") is not currently locked.
+     */
+    public static function getLockoutRemaining(string $identifier): int
+    {
+        $redis = self::getRedis();
+        if ($redis === null) {
+            return 0;
+        }
+
+        $ttl = $redis->ttl(self::lockKey($identifier));
+
+        return $ttl > 0 ? $ttl : 0;
+    }
+
+    /**
+     * Record a failed attempt for the identifier. If this pushes the count
+     * over $maxAttempts within the attempt window, the account is locked for
+     * $lockoutSeconds.
+     */
+    public static function recordFailure(string $identifier, ?int $maxAttempts = null, ?int $lockoutSeconds = null): void
+    {
+        $redis = self::getRedis();
+        if ($redis === null) {
+            return;
+        }
+
+        $maxAttempts ??= self::MAX_ATTEMPTS;
+        $lockoutSeconds ??= self::LOCKOUT_SECONDS;
+
+        $countKey = self::countKey($identifier);
+        $count = $redis->incr($countKey);
+        if ($count === 1) {
+            $redis->expire($countKey, self::ATTEMPT_WINDOW_SECONDS);
+        }
+
+        if ($count >= $maxAttempts) {
+            $redis->setex(self::lockKey($identifier), $lockoutSeconds, '1');
+        }
+    }
+
+    /**
+     * Clear failure tracking for the identifier (call on successful auth).
+     */
+    public static function clear(string $identifier): void
+    {
+        $redis = self::getRedis();
+        if ($redis === null) {
+            return;
+        }
+
+        $redis->del([self::countKey($identifier), self::lockKey($identifier)]);
+    }
+
+    private static function countKey(string $identifier): string
+    {
+        return 'account_lockout:count:' . $identifier;
+    }
+
+    private static function lockKey(string $identifier): string
+    {
+        return 'account_lockout:locked:' . $identifier;
+    }
+
+    private static function getRedis(): ?\Redis
+    {
+        try {
+            $app = App::getInstance(true);
+
+            return $app->getRedisConnection();
+        } catch (\Throwable $e) {
+            return null;
+        }
+    }
+}

--- a/backend/app/Helpers/SessionCookieHelper.php
+++ b/backend/app/Helpers/SessionCookieHelper.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of FeatherPanel.
+ *
+ * Copyright (C) 2025 MythicalSystems Studios
+ * Copyright (C) 2025 FeatherPanel Contributors
+ * Copyright (C) 2025 Cassian Gherman (aka NaysKutzu)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See the LICENSE file or <https://www.gnu.org/licenses/>.
+ */
+
+namespace App\Helpers;
+
+/**
+ * Central place to set/clear the `remember_token` session cookie with secure
+ * flags. Previously every call site used the legacy 4-argument setcookie()
+ * signature (name, value, expire, path), which sets none of HttpOnly,
+ * Secure, or SameSite - leaving the session cookie readable by JavaScript
+ * (XSS -> session hijack) and sendable cross-site (CSRF exposure).
+ */
+class SessionCookieHelper
+{
+    private const COOKIE_NAME = 'remember_token';
+
+    /**
+     * Set the remember_token cookie with secure flags.
+     *
+     * @param string $token The session token value
+     * @param int $expire Unix timestamp when the cookie should expire
+     */
+    public static function set(string $token, int $expire): void
+    {
+        setcookie(self::COOKIE_NAME, $token, [
+            'expires' => $expire,
+            'path' => '/',
+            'secure' => self::isHttps(),
+            'httponly' => true,
+            'samesite' => 'Lax',
+        ]);
+    }
+
+    /**
+     * Clear the remember_token cookie (logout / account deletion / etc).
+     */
+    public static function clear(): void
+    {
+        setcookie(self::COOKIE_NAME, '', [
+            'expires' => time() - 3600,
+            'path' => '/',
+            'secure' => self::isHttps(),
+            'httponly' => true,
+            'samesite' => 'Lax',
+        ]);
+    }
+
+    private static function isHttps(): bool
+    {
+        if (!empty($_SERVER['HTTPS']) && strtolower((string) $_SERVER['HTTPS']) !== 'off') {
+            return true;
+        }
+
+        // Reverse proxy (nginx/Cloudflare) terminates TLS in front of the app.
+        if (!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && strtolower((string) $_SERVER['HTTP_X_FORWARDED_PROTO']) === 'https') {
+            return true;
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## Note

This branch is stacked on #224 (it includes that commit plus the new one below), since both touch the same auth controllers. GitHub will show both diffs until #224 merges - the actual new change here is the `SessionCookieHelper` + reset-token-expiry commit.

## Summary

Found during an internal security review of the authentication flow.

1. **Session cookie missing security flags**: `remember_token` was set via the legacy 4-argument `setcookie(name, value, expire, path)` signature in 6 places (login, 2FA verify, register, logout x2, account deletion), which sets none of `HttpOnly`, `Secure`, or `SameSite`. That leaves the session cookie readable by JavaScript (XSS -> session hijack) and sendable cross-site. Added a `SessionCookieHelper` (auto-detects HTTPS via `$_SERVER[HTTPS]` or `X-Forwarded-Proto` behind a reverse proxy) and switched every call site to it: now sets `HttpOnly`, `Secure` (when on HTTPS), and `SameSite=Lax`.
2. **Password reset tokens never expire**: `ForgotPasswordController` generated a bare random token stored in the shared `mail_verify` column with no expiry - if an old reset email/link leaked later (proxy logs, mail client cache, etc.), it would still work indefinitely. Tokens are now generated as `<64 hex chars>.<unix_expiry>` (1 hour TTL) and both `ResetPasswordController` endpoints (validate + reset) check the embedded expiry, rejecting and invalidating expired tokens instead of accepting them forever. No DB migration needed since `mail_verify` is already `VARCHAR(255)`.

## Testing

Tested live against a running instance:
- `Set-Cookie` header on logout now shows `secure; HttpOnly; SameSite=Lax`.
- A malformed/garbage token format is now rejected by both the GET (validate) and PUT (reset) endpoints with `INVALID_TOKEN`.
- Forgot-password still returns the generic response regardless of whether the email exists (from #224), confirming no regression when combined with this change.
- `php -l` clean on all changed/added files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Added account lockouts after repeated failed login and two-factor authentication attempts, with retry information provided when access is temporarily blocked.
  * Login errors now use a generic message to reduce account enumeration risk.
  * Password reset tokens now expire after one hour and cannot be reused once invalidated.
  * Password recovery responses are more consistent for unknown accounts and internal failures.
  * Session cookies now use enhanced security protections, including HttpOnly, Secure, and SameSite settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->