### PR TITLE
security: block admin privilege escalation, stop leaking daemon tokens

### DIFF
--- a/backend/app/Chat/Node.php
+++ b/backend/app/Chat/Node.php
@@ -435,7 +435,7 @@ class Node
             $params['exclude_node_id'] = $excludeNodeId;
         }
 
-        $sql .= ' ORDER BY n.' . $sortBy . ' ' . $sortOrder;
+        $sql .= ' ORDER BY n.' . self::sanitizeSortColumn($sortBy) . ' ' . (strtoupper($sortOrder) === 'DESC' ? 'DESC' : 'ASC');
         $sql .= ' LIMIT :limit OFFSET :offset';
 
         $stmt = $pdo->prepare($sql);
@@ -623,6 +623,19 @@ class Node
         $stmt->execute();
 
         return $stmt->fetchAll(\PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * Allowlist for ORDER BY column names in searchNodes(). $sortBy is not
+     * currently passed through from any route (index() uses the defaults),
+     * but validating it here closes the SQL injection vector defensively in
+     * case that changes later, consistent with Spell::getColumns()/Mount.php.
+     */
+    private static function sanitizeSortColumn(string $sortBy): string
+    {
+        $allowed = ['id', 'uuid', 'name', 'fqdn', 'location_id', 'created_at', 'updated_at'];
+
+        return in_array($sortBy, $allowed, true) ? $sortBy : 'name';
     }
 
     /**

--- a/backend/app/Controllers/Admin/NodesController.php
+++ b/backend/app/Controllers/Admin/NodesController.php
@@ -257,6 +257,13 @@ class NodesController
         $nodes = Node::searchNodes(page: $page, limit: $limit, search: $search, locationId: $locationId, excludeNodeId: $excludeNodeId);
         $total = Node::getNodesCount(search: $search, locationId: $locationId, excludeNodeId: $excludeNodeId);
 
+        // See enrichNode() for why the daemon token must not appear in list
+        // responses (it grants full API access to the node).
+        foreach ($nodes as &$node) {
+            unset($node['daemon_token'], $node['daemon_token_id']);
+        }
+        unset($node);
+
         $totalPages = ceil($total / $limit);
         $from = ($page - 1) * $limit + 1;
         $to = min($from + $limit - 1, $total);
@@ -2226,6 +2233,15 @@ class NodesController
         $caps = DaemonCapabilities::fromNode($node);
         $node['daemon_type'] = $caps->getType();
         $node['capabilities'] = $caps->toArray();
+
+        // The daemon token grants full API access to the node. It must not
+        // be returned from general list/detail responses - only the
+        // dedicated /setup-command endpoint (which requires the same admin
+        // permission but is an explicit, auditable "reveal" action) should
+        // expose it. Leaving it in every index()/show() response meant it
+        // could end up in browser history, proxy/access logs, or dev tools
+        // for any admin who merely views the nodes list.
+        unset($node['daemon_token'], $node['daemon_token_id']);
 
         return $node;
     }

--- a/backend/app/Controllers/Admin/UsersController.php
+++ b/backend/app/Controllers/Admin/UsersController.php
@@ -834,6 +834,28 @@ class UsersController
             $data['reason']
         );
 
+        // Privilege-escalation guard: this endpoint only requires
+        // ADMIN_USERS_EDIT, but several columns are security-sensitive
+        // (role, 2FA state, session token). An admin with only "edit users"
+        // permission (not full ADMIN_ROOT) must not be able to grant
+        // themselves or another account a higher role, disable/hijack 2FA,
+        // or forge a session by setting remember_token directly. Restrict
+        // those fields to ADMIN_ROOT regardless of what the DB-column-based
+        // denylist above allows through.
+        $rootOnlyFields = ['role_id', 'two_fa_enabled', 'two_fa_key', 'two_fa_blocked', 'remember_token', 'external_id', 'deleted'];
+        $staffUuid = $request->attributes->get('user')['uuid'] ?? null;
+        $isRootAdmin = $staffUuid !== null && \App\Helpers\PermissionHelper::hasPermission($staffUuid, \App\Permissions::ADMIN_ROOT);
+        if (!$isRootAdmin) {
+            $attemptedRootFields = array_intersect($rootOnlyFields, array_keys($data));
+            if (!empty($attemptedRootFields)) {
+                return ApiResponse::error(
+                    'You do not have permission to modify: ' . implode(', ', $attemptedRootFields),
+                    'INSUFFICIENT_PERMISSIONS_FOR_FIELD',
+                    403
+                );
+            }
+        }
+
         if ($app->isDemoMode()) {
             if ($user['id'] === 1) {
                 return ApiResponse::error('Unmanaged actions are not permitted in demo mode', 'UNMANAGED_ACTIONS_NOT_PERMITTED', 400);


### PR DESCRIPTION
## Summary

Found during an internal security review of the admin API.

1. **Privilege escalation via Admin/UsersController::update()**: uses a denylist (unsets a handful of moderation-report fields) instead of an allowlist, so any field mapping to a real DB column passes through - including `role_id`, `two_fa_enabled`, `two_fa_key`, `two_fa_blocked`, `remember_token`, `external_id`, `deleted`. An admin with only `ADMIN_USERS_EDIT` (not full `ADMIN_ROOT`) could grant themselves/another account a higher role, disable/hijack another user's 2FA, or forge a session via `remember_token`. Added an explicit guard requiring `ADMIN_ROOT` for those specific fields.
2. **Daemon token exposure in Admin/NodesController**: `index()` and `show()` returned the fully decrypted `daemon_token`/`daemon_token_id` for every node just from viewing the nodes list or a node's detail page. That token grants full API access to the corresponding FeatherQuilld daemon. There's already a dedicated `/nodes/{id}/setup-command` endpoint for the legitimate reveal use case, so it's now stripped from the general list/detail responses.
3. **Latent SQL injection in Chat/Node::searchNodes()**: `ORDER BY` was built from `$sortBy`/`$sortOrder` with no allowlist, unlike the equivalent query builders elsewhere in the codebase (Spell/Mount/DatabaseInstance). Not currently reachable (no route threads those params through), but fixed defensively with an allowlist for consistency and to close the gap before it becomes reachable.

## Testing

Tested live against a running instance by invoking the actual controller/model code (constructed HTTP requests through the real methods, not just reading the diff):
- `NodesController::index()`/`show()` responses confirmed to no longer include `daemon_token` or `daemon_token_id`, while the raw model-layer `Node::searchNodes()` still returns them internally (as expected - the strip happens at the response boundary).
- `sanitizeSortColumn()` neutralizes a SQLi-shaped sort value (`"id; DROP TABLE ..."`) to the safe default, and passes real column names through unchanged.
- The privilege-escalation guard's core check verified directly: a payload containing `role_id` from a non-`ADMIN_ROOT` caller is blocked and reports the offending field; a payload touching only an allowed field (`first_name`) is not blocked.
- `php -l` clean on all three changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved sorting safeguards to prevent malicious input from affecting node searches.
  * Sensitive daemon credentials are no longer included in node list, detail, create, or update responses.
  * Restricted changes to security-sensitive user account settings to authorized administrators; unauthorized attempts now return an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->