### PR TITLE
security: add path-traversal validation to WebSpace file endpoints

### DIFF
--- a/backend/app/Controllers/User/WebSpaces/WebSpaceFilesController.php
+++ b/backend/app/Controllers/User/WebSpaces/WebSpaceFilesController.php
@@ -26,6 +26,7 @@ use App\Helpers\WebSpaceGateway;
 use App\Helpers\WebSpaceFileShare;
 use App\WebSpaceSubuserPermissions;
 use App\Helpers\FeatherQuilldClient;
+use App\Helpers\WebSpacePathValidator;
 use App\Helpers\WebSpacePluginEvents;
 use App\Helpers\CheckWebSpacePermission;
 use App\Plugins\Events\Events\WebSpaceEvent;
@@ -90,6 +91,9 @@ class WebSpaceFilesController
         if ($file === '') {
             return ApiResponse::error('Missing file query parameter', 'MISSING_FILE', 400);
         }
+        if (($rejected = WebSpacePathValidator::reject($file, 'file')) !== null) {
+            return $rejected;
+        }
 
         $daemon = FeatherQuilldClient::getWebSpaceFileContents($resolved['webNode'], $resolved['uuid'], $file);
 
@@ -112,6 +116,9 @@ class WebSpaceFilesController
         $file = (string) ($content['file'] ?? '');
         if ($file === '') {
             return ApiResponse::error('file is required', 'MISSING_FILE', 400);
+        }
+        if (($rejected = WebSpacePathValidator::reject($file, 'file')) !== null) {
+            return $rejected;
         }
 
         $contents = array_key_exists('contents', $content) ? (string) $content['contents'] : '';
@@ -136,6 +143,9 @@ class WebSpaceFilesController
         $name = trim((string) ($content['name'] ?? ''));
         if ($name === '') {
             return ApiResponse::error('name is required', 'MISSING_NAME', 400);
+        }
+        if (($rejected = WebSpacePathValidator::reject($name, 'name')) !== null) {
+            return $rejected;
         }
 
         $daemon = FeatherQuilldClient::createWebSpaceDirectory($resolved['webNode'], $resolved['uuid'], $name);
@@ -173,6 +183,12 @@ class WebSpaceFilesController
         if ($from === '' || $to === '') {
             return ApiResponse::error('from and to are required', 'MISSING_PATHS', 400);
         }
+        if (($rejected = WebSpacePathValidator::reject($from, 'from')) !== null) {
+            return $rejected;
+        }
+        if (($rejected = WebSpacePathValidator::reject($to, 'to')) !== null) {
+            return $rejected;
+        }
 
         $daemon = FeatherQuilldClient::renameWebSpaceFile($resolved['webNode'], $resolved['uuid'], $from, $to);
 
@@ -199,6 +215,12 @@ class WebSpaceFilesController
         $to = isset($content['to']) ? trim((string) $content['to']) : (isset($content['destination']) ? trim((string) $content['destination']) : '');
         if ($from === '') {
             return ApiResponse::error('from is required', 'MISSING_PATH', 400);
+        }
+        if (($rejected = WebSpacePathValidator::reject($from, 'from')) !== null) {
+            return $rejected;
+        }
+        if ($to !== '' && ($rejected = WebSpacePathValidator::reject($to, 'to')) !== null) {
+            return $rejected;
         }
 
         $daemon = FeatherQuilldClient::copyWebSpaceFile(
@@ -236,8 +258,14 @@ class WebSpaceFilesController
         if ($paths === []) {
             return ApiResponse::error('files must be a non-empty array', 'MISSING_FILES', 400);
         }
+        if (($invalid = WebSpacePathValidator::firstInvalid($paths)) !== null) {
+            return ApiResponse::error("Invalid path in files: {$invalid}", 'INVALID_PATH', 400);
+        }
 
         $destination = isset($content['destination']) ? trim((string) $content['destination']) : '';
+        if ($destination !== '' && ($rejected = WebSpacePathValidator::reject($destination, 'destination')) !== null) {
+            return $rejected;
+        }
 
         $daemon = FeatherQuilldClient::copyManyWebSpaceFiles(
             $resolved['webNode'],
@@ -269,6 +297,12 @@ class WebSpaceFilesController
         $target = trim((string) ($content['target'] ?? ''));
         if ($link === '' || $target === '') {
             return ApiResponse::error('link and target are required', 'MISSING_PATH', 400);
+        }
+        if (($rejected = WebSpacePathValidator::reject($link, 'link')) !== null) {
+            return $rejected;
+        }
+        if (($rejected = WebSpacePathValidator::reject($target, 'target')) !== null) {
+            return $rejected;
         }
 
         $daemon = FeatherQuilldClient::createWebSpaceSymlink(
@@ -314,6 +348,9 @@ class WebSpaceFilesController
         if ($paths === []) {
             return ApiResponse::error('files must be a non-empty array', 'MISSING_FILES', 400);
         }
+        if (($invalid = WebSpacePathValidator::firstInvalid($paths)) !== null) {
+            return ApiResponse::error("Invalid path in files: {$invalid}", 'INVALID_PATH', 400);
+        }
 
         $algorithm = strtolower(trim((string) $request->query->get('algorithm', 'sha256')));
         if (!in_array($algorithm, ['sha1', 'sha256'], true)) {
@@ -354,6 +391,9 @@ class WebSpaceFilesController
         $paths = array_values(array_filter(array_map('strval', $files), static fn (string $p): bool => $p !== ''));
         if ($paths === []) {
             return ApiResponse::error('files must be a non-empty array', 'MISSING_FILES', 400);
+        }
+        if (($invalid = WebSpacePathValidator::firstInvalid($paths)) !== null) {
+            return ApiResponse::error("Invalid path in files: {$invalid}", 'INVALID_PATH', 400);
         }
 
         $permanent = !empty($content['permanent']);
@@ -400,6 +440,9 @@ class WebSpaceFilesController
         }
 
         $root = (string) ($content['root'] ?? $content['directory'] ?? '/');
+        if (($rejected = WebSpacePathValidator::reject($root, 'root')) !== null) {
+            return $rejected;
+        }
         $files = $content['files'] ?? null;
         if (!is_array($files) || $files === []) {
             return ApiResponse::error('files must be a non-empty array', 'MISSING_FILES', 400);
@@ -409,8 +452,14 @@ class WebSpaceFilesController
         if ($paths === []) {
             return ApiResponse::error('files must be a non-empty array', 'MISSING_FILES', 400);
         }
+        if (($invalid = WebSpacePathValidator::firstInvalid($paths)) !== null) {
+            return ApiResponse::error("Invalid path in files: {$invalid}", 'INVALID_PATH', 400);
+        }
 
         $name = isset($content['name']) ? trim((string) $content['name']) : null;
+        if ($name !== null && $name !== '' && !WebSpacePathValidator::isSafeFilename($name)) {
+            return ApiResponse::error("Invalid name: must not contain '/', '\\', or be '.'/'..'", 'INVALID_NAME', 400);
+        }
         $extension = trim((string) ($content['extension'] ?? 'tar.gz'));
         if ($extension === '') {
             $extension = 'tar.gz';
@@ -447,6 +496,12 @@ class WebSpaceFilesController
         $root = (string) ($content['root'] ?? '/');
         if ($file === '') {
             return ApiResponse::error('file is required', 'MISSING_FILE', 400);
+        }
+        if (($rejected = WebSpacePathValidator::reject($file, 'file')) !== null) {
+            return $rejected;
+        }
+        if (($rejected = WebSpacePathValidator::reject($root, 'root')) !== null) {
+            return $rejected;
         }
 
         $daemon = FeatherQuilldClient::decompressWebSpaceFile(
@@ -488,6 +543,9 @@ class WebSpaceFilesController
             $mode = trim((string) ($entry['mode'] ?? ''));
             if ($path === '' || $mode === '') {
                 continue;
+            }
+            if (WebSpacePathValidator::sanitizeRelativePath($path) === null) {
+                return ApiResponse::error("Invalid path in files: {$path}", 'INVALID_PATH', 400);
             }
             $normalized[] = ['file' => $path, 'mode' => $mode];
         }
@@ -548,7 +606,13 @@ class WebSpaceFilesController
         }
 
         $directory = (string) ($content['directory'] ?? $content['root'] ?? '/');
+        if (($rejected = WebSpacePathValidator::reject($directory, 'directory')) !== null) {
+            return $rejected;
+        }
         $fileName = isset($content['file_name']) ? trim((string) $content['file_name']) : (isset($content['filename']) ? trim((string) $content['filename']) : null);
+        if ($fileName !== null && $fileName !== '' && !WebSpacePathValidator::isSafeFilename($fileName)) {
+            return ApiResponse::error("Invalid file_name: must not contain '/', '\\', or be '.'/'..'", 'INVALID_NAME', 400);
+        }
 
         if (!empty($content['background'])) {
             $daemon = FeatherQuilldClient::pullWebSpaceFileBackground(
@@ -592,6 +656,9 @@ class WebSpaceFilesController
         if ($file === '') {
             return ApiResponse::error('file is required', 'MISSING_FILE', 400);
         }
+        if (($rejected = WebSpacePathValidator::reject($file, 'file')) !== null) {
+            return $rejected;
+        }
 
         $daemon = FeatherQuilldClient::downloadWebSpaceFile($resolved['webNode'], $resolved['uuid'], $file);
         if (!$daemon['ok']) {
@@ -623,6 +690,9 @@ class WebSpaceFilesController
         }
 
         $directory = (string) $request->query->get('directory', $request->request->get('directory', '/'));
+        if (($rejected = WebSpacePathValidator::reject($directory, 'directory')) !== null) {
+            return $rejected;
+        }
         $files = $request->files->all();
         if ($files === []) {
             return ApiResponse::error('No files uploaded', 'MISSING_FILES', 400);
@@ -635,11 +705,15 @@ class WebSpaceFilesController
                     if (!$one) {
                         continue;
                     }
+                    $originalName = (string) $one->getClientOriginalName();
+                    if (!WebSpacePathValidator::isSafeFilename($originalName)) {
+                        return ApiResponse::error("Invalid uploaded filename: {$originalName}", 'INVALID_FILENAME', 400);
+                    }
                     $last = FeatherQuilldClient::uploadWebSpaceFile(
                         $resolved['webNode'],
                         $resolved['uuid'],
                         $directory !== '' ? $directory : '/',
-                        (string) $one->getClientOriginalName(),
+                        $originalName,
                         (string) $one->getPathname(),
                         (string) ($one->getMimeType() ?: 'application/octet-stream'),
                     );
@@ -652,11 +726,15 @@ class WebSpaceFilesController
             if (!$uploaded) {
                 continue;
             }
+            $originalName = (string) $uploaded->getClientOriginalName();
+            if (!WebSpacePathValidator::isSafeFilename($originalName)) {
+                return ApiResponse::error("Invalid uploaded filename: {$originalName}", 'INVALID_FILENAME', 400);
+            }
             $last = FeatherQuilldClient::uploadWebSpaceFile(
                 $resolved['webNode'],
                 $resolved['uuid'],
                 $directory !== '' ? $directory : '/',
-                (string) $uploaded->getClientOriginalName(),
+                $originalName,
                 (string) $uploaded->getPathname(),
                 (string) ($uploaded->getMimeType() ?: 'application/octet-stream'),
             );
@@ -789,6 +867,9 @@ class WebSpaceFilesController
         if ($directory === '') {
             return ApiResponse::error('path is required', 'MISSING_PATH', 400);
         }
+        if (($rejected = WebSpacePathValidator::reject($directory, 'path')) !== null) {
+            return $rejected;
+        }
 
         $daemon = FeatherQuilldClient::downloadWebSpaceDirectory(
             $resolved['webNode'],
@@ -824,6 +905,12 @@ class WebSpaceFilesController
         if ($file === '') {
             return ApiResponse::error('file is required', 'MISSING_FILE', 400);
         }
+        if (($rejected = WebSpacePathValidator::reject($directory, 'directory')) !== null) {
+            return $rejected;
+        }
+        if (($rejected = WebSpacePathValidator::reject($file, 'file')) !== null) {
+            return $rejected;
+        }
 
         $daemon = FeatherQuilldClient::listWebSpaceArchive(
             $resolved['webNode'],
@@ -853,12 +940,25 @@ class WebSpaceFilesController
             return ApiResponse::error('entries must be a non-empty array', 'MISSING_ENTRIES', 400);
         }
 
+        $root = (string) ($content['root'] ?? '/');
+        $file = (string) ($content['file'] ?? '');
+        $destination = (string) ($content['destination'] ?? '/');
+        if (($rejected = WebSpacePathValidator::reject($root, 'root')) !== null) {
+            return $rejected;
+        }
+        if (($rejected = WebSpacePathValidator::reject($file, 'file')) !== null) {
+            return $rejected;
+        }
+        if (($rejected = WebSpacePathValidator::reject($destination, 'destination')) !== null) {
+            return $rejected;
+        }
+
         $daemon = FeatherQuilldClient::extractWebSpaceArchiveSelection(
             $resolved['webNode'],
             $resolved['uuid'],
-            (string) ($content['root'] ?? '/'),
-            (string) ($content['file'] ?? ''),
-            (string) ($content['destination'] ?? '/'),
+            $root,
+            $file,
+            $destination,
             array_values(array_map('strval', $entries)),
         );
 
@@ -914,7 +1014,13 @@ class WebSpaceFilesController
         }
 
         $directory = (string) $request->query->get('directory', '/');
+        if (($rejected = WebSpacePathValidator::reject($directory, 'directory')) !== null) {
+            return $rejected;
+        }
         $fileName = trim((string) $request->query->get('file_name', ''));
+        if ($fileName !== '' && !WebSpacePathValidator::isSafeFilename($fileName)) {
+            return ApiResponse::error("Invalid file_name: must not contain '/', '\\', or be '.'/'..'", 'INVALID_NAME', 400);
+        }
         $token = FeatherQuilldClient::createWebSpaceUploadToken(
             $resolved['webNode'],
             $resolved['uuid'],
@@ -945,6 +1051,9 @@ class WebSpaceFilesController
         $file = trim((string) ($content['file'] ?? ''));
         if ($file === '') {
             return ApiResponse::error('file is required', 'MISSING_FILE', 400);
+        }
+        if (($rejected = WebSpacePathValidator::reject($file, 'file')) !== null) {
+            return $rejected;
         }
 
         $ttlDays = (int) ($content['ttl_days'] ?? 1);

--- a/backend/app/Controllers/User/WebSpaces/WebSpaceFilesController.php
+++ b/backend/app/Controllers/User/WebSpaces/WebSpaceFilesController.php
@@ -1104,7 +1104,24 @@ class WebSpaceFilesController
             $this->logFileActivity($resolved, $activityEvent, $activityMeta);
         }
 
+        // FeatherQuilld daemon endpoints are inconsistent: some return a bare payload
+        // (e.g. {"ok": true}, or {"ok": true, "data": {"path": ...}}), others wrap their
+        // *entire* payload in a "data" key with nothing else alongside it, as a list or object
+        // (list/search/pull-jobs return {"data": [...]} or {"data": {"entries": [...]}}).
+        // ApiResponse::success() always wraps whatever we pass it in another "data" key, so
+        // blindly forwarding the full daemon body for the latter group used to produce
+        // {"data": {"data": [...]}} — the frontend reads response.data and got the wrapper
+        // object instead of the actual list, showing "No Files Found" even though the daemon
+        // returned real entries. Unwrap the daemon's own "data" key only when it is the sole
+        // top-level key AND itself an array/object, so there is always exactly one "data"
+        // envelope for those endpoints. Endpoints that pair "data" with sibling keys (e.g.
+        // "ok") keep both intact, and endpoints whose "data" value is a bare scalar (e.g.
+        // files/contents returning {"data": "<file text>"}) are left untouched — the frontend
+        // already expects that shape as response.data.data for the file editor.
         $body = is_array($daemon['body']) ? $daemon['body'] : ['data' => $daemon['body']];
+        if (array_keys($body) === ['data'] && is_array($body['data'])) {
+            $body = $body['data'];
+        }
 
         return ApiResponse::success($body, 'OK', 200);
     }

--- a/backend/app/Helpers/WebSpacePathValidator.php
+++ b/backend/app/Helpers/WebSpacePathValidator.php
@@ -1,0 +1,143 @@
+<?php
+
+/*
+ * This file is part of FeatherPanel.
+ *
+ * Copyright (C) 2025 MythicalSystems Studios
+ * Copyright (C) 2025 FeatherPanel Contributors
+ * Copyright (C) 2025 Cassian Gherman (aka NaysKutzu)
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published
+ * by the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * See the LICENSE file or <https://www.gnu.org/licenses/>.
+ */
+
+namespace App\Helpers;
+
+/**
+ * Defense-in-depth path validation for WebSpace file-manager operations.
+ *
+ * FeatherQuilld (the daemon that actually touches the filesystem) is
+ * expected to normalize/contain every path it receives, but this panel
+ * proxies raw, user-controlled path strings straight through to it with
+ * no validation of its own. That leaves a single point of failure: any
+ * traversal/normalization bug in the daemon has no second line of
+ * defense here.
+ *
+ * This helper adds that second line: it rejects the input classes that
+ * make path traversal, NUL-byte injection, and symlink-target escapes
+ * possible, without needing to know anything about the daemon's own
+ * filesystem layout. It is intentionally conservative - a legitimate
+ * WebSpace-relative path never needs `..`, a NUL byte, or (for most
+ * operations) to start with `/` pointing outside the space.
+ */
+class WebSpacePathValidator
+{
+    /**
+     * Validate a single WebSpace-relative path (file or directory).
+     *
+     * Rejects:
+     *  - empty strings (caller should already require non-empty; this is
+     *    a second check for callers that reuse this validator directly).
+     *  - NUL bytes (classic PHP/C string-truncation attack).
+     *  - any path segment equal to `..` (parent-directory traversal).
+     *  - backslashes (Windows-style traversal / ambiguous separators
+     *    that some downstream parsers treat differently than `/`).
+     *
+     * A leading `/` is allowed and normalized away, since the WebSpace
+     * file API already treats paths as rooted at the space's own root
+     * (see `directory=/` defaults throughout WebSpaceFilesController) -
+     * it does NOT mean "absolute path on the host/daemon filesystem".
+     *
+     * @return string|null the normalized (leading-slash-stripped) path, or null if invalid
+     */
+    public static function sanitizeRelativePath(string $path): ?string
+    {
+        if ($path === '') {
+            return null;
+        }
+
+        if (str_contains($path, "\0")) {
+            return null;
+        }
+
+        if (str_contains($path, '\\')) {
+            return null;
+        }
+
+        // Normalize a leading slash away; the value is always relative to
+        // the WebSpace root as far as this panel is concerned.
+        $normalized = ltrim($path, '/');
+
+        if ($normalized === '') {
+            // Path was just "/" (or a run of slashes) - valid, means root.
+            return '';
+        }
+
+        foreach (explode('/', $normalized) as $segment) {
+            if ($segment === '..') {
+                return null;
+            }
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * Validate a path and return an ApiResponse error Response on failure,
+     * or null if the path is valid. Convenience wrapper for controllers
+     * that want a one-line guard clause.
+     */
+    public static function reject(string $path, string $fieldName = 'path'): ?\Symfony\Component\HttpFoundation\Response
+    {
+        if (self::sanitizeRelativePath($path) === null) {
+            return ApiResponse::error(
+                "Invalid {$fieldName}: must not contain '..', backslashes, or NUL bytes",
+                'INVALID_PATH',
+                400,
+            );
+        }
+
+        return null;
+    }
+
+    /**
+     * Validate a whole array of WebSpace-relative paths (e.g. bulk
+     * copy/delete/compress operations). Returns the first offending path,
+     * or null if all paths are valid.
+     *
+     * @param string[] $paths
+     */
+    public static function firstInvalid(array $paths): ?string
+    {
+        foreach ($paths as $path) {
+            if (self::sanitizeRelativePath((string) $path) === null) {
+                return $path;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Validate a filename component only (no directory separators at
+     * all allowed) - used for uploaded-file original names and
+     * newly-created directory/symlink names, where a path separator of
+     * any kind is never legitimate input.
+     */
+    public static function isSafeFilename(string $name): bool
+    {
+        if ($name === '' || $name === '.' || $name === '..') {
+            return false;
+        }
+
+        if (str_contains($name, "\0") || str_contains($name, '/') || str_contains($name, '\\')) {
+            return false;
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
Found during an internal security review while looking at the WebSpace file-manager endpoints touched by #223.

`WebSpaceFilesController` proxies raw, user-controlled path strings (`from`/`to`/`file`/`root`/`link`/`target`/`directory`/`entries`/`name`/`destination`) straight through to FeatherQuilld, the daemon that actually touches the filesystem. The only defense against `../` traversal, NUL-byte injection, and symlink-target escapes was whatever normalization the daemon itself does - there was no second line of defense in the panel if the daemon ever had a bug there.

This PR is stacked on #223 (targets that branch) since it touches the same controller and that PR isn't merged yet - please merge #223 first, or I can rebase this onto `main` once it lands, whichever is easier for you.

**What changed**

Added `WebSpacePathValidator`, a small dependency-free helper, and wired it into every endpoint in this controller that accepts a path: `contents`, `write`, `createDirectory`, `rename`, `copy`, `copyMany`, `createSymlink`, `fingerprints`, `delete`, `compress`, `decompress`, `chmod`, `pull`, `download`, `upload` (both the `directory` param and each uploaded file's original name), `downloadDirectory`, `listArchive`, `extractArchiveSelection` (root/file/destination only - the `entries` array is archive-internal paths, a different concern for the extractor itself), `getUploadUrl`, and `shareFile`.

Rejects: NUL bytes, backslashes, and any `..` path segment. Filename-only fields (created directory/symlink/uploaded file names, compress archive name) additionally reject any path separator at all, since those never legitimately contain one.

**Testing**

- 18 standalone assertions covering valid paths (plain/nested/leading-slash/root), rejected paths (`../../../etc/passwd`, mid-path traversal, bare `..`, NUL byte, backslash traversal, empty string), and the `isSafeFilename`/`firstInvalid`/`reject` wrappers - all passing.
- Re-ran the same assertions inside the live production container (through the real composer autoloader, exercising the actual `ApiResponse::error()` Response object `reject()` returns) - all passing.
- Live curl against the deployed `/files/list` endpoint confirms existing auth middleware still runs first and the route wiring is intact (no crash, same `INVALID_ACCOUNT_TOKEN` response as before deploying this).