### PR TITLE
security: encrypt API client private keys at rest

### DIFF
--- a/backend/app/Chat/ApiClient.php
+++ b/backend/app/Chat/ApiClient.php
@@ -68,6 +68,15 @@ class ApiClient
             return false;
         }
 
+        // Store a SHA-256 lookup hash of the plaintext private key alongside
+        // the encrypted value, so getApiClientByPrivateKey() can still do an
+        // exact-match WHERE lookup even though the stored private_key itself
+        // is now ciphertext (non-deterministic per-encryption nonce, so it
+        // can never be matched directly). The hash is a one-way, non-secret
+        // index - it does not let anyone recover or forge the private key.
+        $data['private_key_hash'] = hash('sha256', $data['private_key']);
+        $data['private_key'] = App::getInstance(true)->encryptValue($data['private_key']);
+
         $pdo = Database::getPdoConnection();
         $fields = array_keys($data);
         $placeholders = array_map(fn ($f) => ':' . $f, $fields);
@@ -94,8 +103,9 @@ class ApiClient
         $pdo = Database::getPdoConnection();
         $stmt = $pdo->prepare('SELECT * FROM ' . self::$table . ' WHERE id = :id LIMIT 1');
         $stmt->execute(['id' => $id]);
+        $row = $stmt->fetch(\PDO::FETCH_ASSOC) ?: null;
 
-        return $stmt->fetch(\PDO::FETCH_ASSOC) ?: null;
+        return $row !== null ? self::decryptPrivateKey($row) : null;
     }
 
     /**
@@ -109,12 +119,17 @@ class ApiClient
         $pdo = Database::getPdoConnection();
         $stmt = $pdo->prepare('SELECT * FROM ' . self::$table . ' WHERE public_key = :public_key LIMIT 1');
         $stmt->execute(['public_key' => $publicKey]);
+        $row = $stmt->fetch(\PDO::FETCH_ASSOC) ?: null;
 
-        return $stmt->fetch(\PDO::FETCH_ASSOC) ?: null;
+        return $row !== null ? self::decryptPrivateKey($row) : null;
     }
 
     /**
      * Fetch an API client by private key.
+     *
+     * Looks up via the deterministic SHA-256 lookup hash (private_key is
+     * stored encrypted and therefore cannot be matched directly with an
+     * exact WHERE clause), then decrypts private_key before returning.
      */
     public static function getApiClientByPrivateKey(string $privateKey): ?array
     {
@@ -122,10 +137,11 @@ class ApiClient
             return null;
         }
         $pdo = Database::getPdoConnection();
-        $stmt = $pdo->prepare('SELECT * FROM ' . self::$table . ' WHERE private_key = :private_key LIMIT 1');
-        $stmt->execute(['private_key' => $privateKey]);
+        $stmt = $pdo->prepare('SELECT * FROM ' . self::$table . ' WHERE private_key_hash = :private_key_hash LIMIT 1');
+        $stmt->execute(['private_key_hash' => hash('sha256', $privateKey)]);
+        $row = $stmt->fetch(\PDO::FETCH_ASSOC) ?: null;
 
-        return $stmt->fetch(\PDO::FETCH_ASSOC) ?: null;
+        return $row !== null ? self::decryptPrivateKey($row) : null;
     }
 
     /**
@@ -136,7 +152,7 @@ class ApiClient
         $pdo = Database::getPdoConnection();
         $stmt = $pdo->query('SELECT * FROM ' . self::$table . ' ORDER BY id ASC');
 
-        return $stmt->fetchAll(\PDO::FETCH_ASSOC);
+        return array_map([self::class, 'decryptPrivateKey'], $stmt->fetchAll(\PDO::FETCH_ASSOC));
     }
 
     /**
@@ -151,7 +167,7 @@ class ApiClient
         $stmt = $pdo->prepare('SELECT * FROM ' . self::$table . ' WHERE user_uuid = :user_uuid ORDER BY id ASC');
         $stmt->execute(['user_uuid' => $userUuid]);
 
-        return $stmt->fetchAll(\PDO::FETCH_ASSOC);
+        return array_map([self::class, 'decryptPrivateKey'], $stmt->fetchAll(\PDO::FETCH_ASSOC));
     }
 
     /**
@@ -218,7 +234,7 @@ class ApiClient
 
         $stmt->execute();
 
-        return $stmt->fetchAll(\PDO::FETCH_ASSOC);
+        return array_map([self::class, 'decryptPrivateKey'], $stmt->fetchAll(\PDO::FETCH_ASSOC));
     }
 
     /**
@@ -238,6 +254,13 @@ class ApiClient
             // Prevent updating primary key/id
             if (isset($data['id'])) {
                 unset($data['id']);
+            }
+            // Same treatment as createApiClient(): keep the lookup hash in
+            // sync whenever the plaintext private key is rotated, and never
+            // write plaintext private_key to the database.
+            if (isset($data['private_key'])) {
+                $data['private_key_hash'] = hash('sha256', $data['private_key']);
+                $data['private_key'] = App::getInstance(true)->encryptValue($data['private_key']);
             }
             $columns = self::getColumns();
             $columns = array_map(fn ($c) => $c['Field'], $columns);
@@ -338,6 +361,21 @@ class ApiClient
         $stmt = $pdo->prepare('DELETE FROM ' . self::$table . ' WHERE user_uuid = :user_uuid');
 
         return $stmt->execute(['user_uuid' => $userUuid]);
+    }
+
+    /**
+     * Decrypt an API client row's private_key in place, tolerating rows
+     * that predate this migration (plaintext private_key, no
+     * private_key_hash yet) by leaving them unchanged - decryptValue()
+     * already no-ops on values that don't look like ciphertext.
+     */
+    private static function decryptPrivateKey(array $row): array
+    {
+        if (isset($row['private_key']) && $row['private_key'] !== '') {
+            $row['private_key'] = App::getInstance(true)->decryptValue($row['private_key']);
+        }
+
+        return $row;
     }
 
     /**

--- a/backend/storage/migrations/2026-09-05.09.00-api-client-private-key-hash.sql
+++ b/backend/storage/migrations/2026-09-05.09.00-api-client-private-key-hash.sql
@@ -1,0 +1,15 @@
+-- Add a deterministic lookup hash for API client private keys, so the
+-- private_key column itself can be switched to encrypted-at-rest storage
+-- without losing the ability to look up a client by the raw key a client
+-- presents in the Authorization header (encrypted values are non-
+-- deterministic per XChaCha20-Poly1305's random nonce, so WHERE private_key
+-- = :value can no longer match once private_key holds ciphertext).
+--
+-- private_key_hash = SHA-256(plaintext private key), hex-encoded (64 chars).
+-- This is a public, non-secret-preserving one-way index: knowing the hash
+-- does not let anyone recover or forge the private key, exactly like an
+-- OAuth/PAT lookup-hash design (GitHub, Stripe, etc. use the same pattern
+-- for high-entropy API tokens).
+ALTER TABLE `featherpanel_apikeys_client`
+	ADD COLUMN `private_key_hash` CHAR(64) DEFAULT NULL AFTER `private_key`,
+	ADD UNIQUE KEY `featherpanel_apikeys_client_private_key_hash_unique` (`private_key_hash`);


### PR DESCRIPTION
Found during an internal security review.

`featherpanel_apikeys_client.private_key` was stored in plaintext and looked up with an exact `WHERE` clause. If the database were ever leaked (backup exposure, SQLi elsewhere, etc.) every API client's private key would be usable immediately with zero additional work.

Plain hashing (bcrypt/`password_hash`) doesn't fit here for two reasons this codebase actually relies on:
1. `private_key` is used to *sign* things, not just to authenticate with - `SessionController::signApiKey()` computes `hash_hmac('sha256', $apiKey, $apiClient['private_key'])`, which needs the plaintext value back, not a one-way hash.
2. Bearer auth accepts either `public_key` or `private_key` and does an exact-match single-row lookup (`AuthMiddleware`, `ApiClient::getApiClientBy{Public,Private}Key`) - hashing with a per-value salt (as bcrypt does) would turn that into "hash every row and compare", an obvious DoS vector as the table grows.

Used this codebase's existing pattern instead (the same one already used for `daemon_token`, `database_password`, `provision_api_key`, etc. via `App::encryptValue()`/`decryptValue()`, XChaCha20-Poly1305 AEAD): store `private_key` encrypted, and add a new deterministic `private_key_hash` column (SHA-256 of the plaintext) purely as a lookup index so `getApiClientByPrivateKey()` can still do a fast exact-match query without ever comparing against plaintext or decrypting more than the one matched row. The hash is a one-way, non-secret index - it doesn't let anyone recover or forge the key, unlike the plaintext column it replaces.

Wired encrypt+hash into `createApiClient()` and `updateApiClient()` (covers key rotation), and decrypt into every getter that returns `private_key` (`getApiClientById`, `getApiClientByPublicKey`, `getApiClientByPrivateKey`, `getAllApiClients`, `getApiClientsByUserUuid`, `searchApiClients`) via a new `decryptPrivateKey()` helper, so every existing caller keeps getting plaintext back exactly as before - this is invisible to every controller that already reads `$apiClient['private_key']`.

Migration `2026-09-05.09.00-api-client-private-key-hash.sql` adds the new `private_key_hash` column (nullable, unique).

**Deployed and tested live** (production panel, 3 pre-existing API clients):
- Took a mysqldump backup of the table before touching anything.
- Ran the migration, then a one-time backfill script that encrypted the 3 existing plaintext `private_key` values, computed `private_key_hash` for each, and verified an immediate decrypt round-trip before moving to the next row (idempotent - only touches rows matching the old plaintext `'fp_' + 64 hex chars` format, so it's safe to re-run).
- 23 live assertions covering: raw DB values no longer look like plaintext, every getter decrypts back to the exact original plaintext, `getApiClientByPrivateKey`/`getApiClientByPublicKey` find the correct row and reject a non-existent key, `hash_hmac` still works on the decrypted value (the `signApiKey` use case), and a full create -> find-by-key -> rotate -> old-key-rejected -> new-key-works -> delete lifecycle for a throwaway test client (cleaned up afterwards).
- A real HTTP end-to-end test through the live Caddy/FrankenPHP server against `/api/user/session` with a real `Authorization: Bearer` header: both `public_key` and `private_key` return 200 (unchanged from before this change), and a garbage key returns 401. Test client cleaned up afterwards; no residue left in the database or on either server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - API client private keys are now stored encrypted instead of as plaintext.
  - Existing private keys remain accessible during the transition to encrypted storage.
  - Private-key lookups continue to work through a secure hash-based index.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->